### PR TITLE
S2a: pure-Dart calendar_engine package + 30 unit tests

### DIFF
--- a/packages/calendar_engine/analysis_options.yaml
+++ b/packages/calendar_engine/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/packages/calendar_engine/lib/calendar_engine.dart
+++ b/packages/calendar_engine/lib/calendar_engine.dart
@@ -1,0 +1,11 @@
+/// Pure-Dart calendar math for fictional in-world calendars.
+///
+/// No Flutter, no Firebase, no I/O. All types are immutable and `const`-able
+/// where possible. Replacing the storage layer must not require touching
+/// this package.
+library;
+
+export 'src/calendar_config.dart';
+export 'src/engine.dart';
+export 'src/moon.dart';
+export 'src/world_date.dart';

--- a/packages/calendar_engine/lib/src/calendar_config.dart
+++ b/packages/calendar_engine/lib/src/calendar_config.dart
@@ -1,0 +1,95 @@
+import 'moon.dart';
+
+/// One month definition: name + length in days (the *base* length, before
+/// any leap-rule additions are applied).
+class MonthDef {
+  const MonthDef({required this.name, required this.days})
+      : assert(days > 0, 'month length must be positive');
+
+  final String name;
+  final int days;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MonthDef && other.name == name && other.days == days;
+
+  @override
+  int get hashCode => Object.hash(name, days);
+}
+
+/// Optional "every N years, add 1 day to month X" leap rule. Modeled as a
+/// single insertion to keep MVP scope. Gregorian-style nested exceptions
+/// and inserted-month variants are explicitly out of scope (see CONTEXT.md).
+class LeapRule {
+  const LeapRule({
+    required this.everyNYears,
+    required this.extraDayInMonthIndex,
+  })  : assert(everyNYears > 0, 'everyNYears must be positive'),
+        assert(extraDayInMonthIndex >= 0, 'monthIndex must be non-negative');
+
+  final int everyNYears;
+  final int extraDayInMonthIndex;
+
+  bool isLeapYear(int year) => year % everyNYears == 0;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LeapRule &&
+          other.everyNYears == everyNYears &&
+          other.extraDayInMonthIndex == extraDayInMonthIndex;
+
+  @override
+  int get hashCode => Object.hash(everyNYears, extraDayInMonthIndex);
+}
+
+/// Per-world calendar configuration. The engine treats `(startYear, 0, 1)`
+/// as the epoch reference — i.e. day 0 of `daysSinceEpoch`.
+class CalendarConfig {
+  const CalendarConfig({
+    required this.daysPerWeek,
+    required this.weekdayNames,
+    required this.months,
+    required this.epochName,
+    required this.startYear,
+    this.leapRule,
+    this.moons = const [],
+  }) : assert(daysPerWeek > 0, 'daysPerWeek must be positive');
+  // List-length asserts can't be const-evaluated, so callers are responsible
+  // for ensuring `months` and `weekdayNames` are non-empty.
+
+  final int daysPerWeek;
+  final List<String> weekdayNames;
+  final List<MonthDef> months;
+  final String epochName;
+  final int startYear;
+  final LeapRule? leapRule;
+  final List<MoonDef> moons;
+
+  /// Length of the given month in the given year, honoring the leap rule.
+  int daysInMonth(int year, int monthIndex) {
+    final base = months[monthIndex].days;
+    if (leapRule != null &&
+        monthIndex == leapRule!.extraDayInMonthIndex &&
+        leapRule!.isLeapYear(year)) {
+      return base + 1;
+    }
+    return base;
+  }
+
+  /// Total days in the given year, honoring the leap rule.
+  int daysInYear(int year) {
+    var total = 0;
+    for (var i = 0; i < months.length; i++) {
+      total += daysInMonth(year, i);
+    }
+    return total;
+  }
+
+  bool isValidDate(int year, int monthIndex, int day) {
+    if (monthIndex < 0 || monthIndex >= months.length) return false;
+    if (day < 1 || day > daysInMonth(year, monthIndex)) return false;
+    return true;
+  }
+}

--- a/packages/calendar_engine/lib/src/engine.dart
+++ b/packages/calendar_engine/lib/src/engine.dart
@@ -1,0 +1,120 @@
+import 'calendar_config.dart';
+import 'moon.dart';
+import 'world_date.dart';
+
+/// Days from `(config.startYear, 0, 1)` to `date`. Negative for dates earlier
+/// than the epoch. The epoch itself is day 0.
+int daysSinceEpoch(WorldDate date, CalendarConfig config) {
+  var total = 0;
+
+  // Year part. Walk forward from startYear (or backward) summing year lengths.
+  if (date.year >= config.startYear) {
+    for (var y = config.startYear; y < date.year; y++) {
+      total += config.daysInYear(y);
+    }
+  } else {
+    for (var y = config.startYear - 1; y >= date.year; y--) {
+      total -= config.daysInYear(y);
+    }
+  }
+
+  // Month part within `date.year`.
+  for (var m = 0; m < date.monthIndex; m++) {
+    total += config.daysInMonth(date.year, m);
+  }
+
+  // Day part (day is 1-based; day 1 = no offset within the month).
+  total += date.day - 1;
+
+  return total;
+}
+
+/// Inverse of [daysSinceEpoch]: turn a day count back into a [WorldDate].
+WorldDate fromDaysSinceEpoch(int totalDays, CalendarConfig config) {
+  var year = config.startYear;
+  var remaining = totalDays;
+
+  if (remaining >= 0) {
+    while (true) {
+      final yearLen = config.daysInYear(year);
+      if (remaining < yearLen) break;
+      remaining -= yearLen;
+      year += 1;
+    }
+  } else {
+    while (remaining < 0) {
+      year -= 1;
+      remaining += config.daysInYear(year);
+    }
+  }
+
+  var monthIndex = 0;
+  while (true) {
+    final monthLen = config.daysInMonth(year, monthIndex);
+    if (remaining < monthLen) break;
+    remaining -= monthLen;
+    monthIndex += 1;
+    // Safety: months count is finite per config; loop must terminate because
+    // the year-stripping above guaranteed remaining < daysInYear.
+  }
+
+  return WorldDate(year: year, monthIndex: monthIndex, day: remaining + 1);
+}
+
+/// Return `date + n` days. `n` may be negative.
+WorldDate addDays(WorldDate date, int n, CalendarConfig config) {
+  return fromDaysSinceEpoch(daysSinceEpoch(date, config) + n, config);
+}
+
+/// `b - a` in days. Positive when `b` is after `a`.
+int daysBetween(WorldDate a, WorldDate b, CalendarConfig config) {
+  return daysSinceEpoch(b, config) - daysSinceEpoch(a, config);
+}
+
+/// Weekday index (0..daysPerWeek-1). Day 0 of the epoch is weekday 0.
+int weekdayAt(WorldDate date, CalendarConfig config) {
+  final d = daysSinceEpoch(date, config);
+  return _mod(d, config.daysPerWeek);
+}
+
+String weekdayNameAt(WorldDate date, CalendarConfig config) {
+  return config.weekdayNames[weekdayAt(date, config)];
+}
+
+/// Phase of one moon at a given date.
+MoonObservation moonPhaseAt(
+  WorldDate date,
+  MoonDef moon,
+  CalendarConfig config,
+) {
+  final d = daysSinceEpoch(date, config);
+  final cycleDay = _mod(d + moon.offsetDays, moon.periodDays);
+  // Map [0, period) into 8 equal-ish phase buckets.
+  // Bucket boundaries at i * period / 8 for i in [0..8].
+  final phaseIndex = (cycleDay * 8) ~/ moon.periodDays;
+  return MoonObservation(
+    moon: moon,
+    phase: MoonPhase.values[phaseIndex.clamp(0, 7)],
+    dayInCycle: cycleDay,
+  );
+}
+
+/// Phases for every moon defined on the world's calendar.
+List<MoonObservation> moonPhasesAt(WorldDate date, CalendarConfig config) {
+  return [
+    for (final moon in config.moons) moonPhaseAt(date, moon, config),
+  ];
+}
+
+/// Human-readable form: "12 Hammer, 1493 DR (Sul)".
+String formatDate(WorldDate date, CalendarConfig config) {
+  final monthName = config.months[date.monthIndex].name;
+  final weekday = weekdayNameAt(date, config);
+  return '${date.day} $monthName, ${date.year} ${config.epochName} ($weekday)';
+}
+
+/// Mathematical mod that always returns a non-negative result.
+int _mod(int a, int n) {
+  final r = a % n;
+  return r < 0 ? r + n : r;
+}

--- a/packages/calendar_engine/lib/src/moon.dart
+++ b/packages/calendar_engine/lib/src/moon.dart
@@ -1,0 +1,87 @@
+/// Definition of one moon in a world's sky. Phase at any date is computed
+/// from `(daysSinceEpoch + offsetDays) mod periodDays`.
+class MoonDef {
+  const MoonDef({
+    required this.name,
+    required this.periodDays,
+    required this.offsetDays,
+    required this.color,
+  }) : assert(periodDays > 0, 'periodDays must be positive');
+
+  final String name;
+  final int periodDays;
+  final int offsetDays;
+  final String color;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MoonDef &&
+          other.name == name &&
+          other.periodDays == periodDays &&
+          other.offsetDays == offsetDays &&
+          other.color == color;
+
+  @override
+  int get hashCode => Object.hash(name, periodDays, offsetDays, color);
+}
+
+/// Standard 8 lunar phases in order around the cycle.
+enum MoonPhase {
+  newMoon,
+  waxingCrescent,
+  firstQuarter,
+  waxingGibbous,
+  fullMoon,
+  waningGibbous,
+  lastQuarter,
+  waningCrescent;
+
+  /// Short symbol for textual UI rendering (e.g. "🌒 2/8").
+  String get symbol {
+    switch (this) {
+      case MoonPhase.newMoon:
+        return '🌑';
+      case MoonPhase.waxingCrescent:
+        return '🌒';
+      case MoonPhase.firstQuarter:
+        return '🌓';
+      case MoonPhase.waxingGibbous:
+        return '🌔';
+      case MoonPhase.fullMoon:
+        return '🌕';
+      case MoonPhase.waningGibbous:
+        return '🌖';
+      case MoonPhase.lastQuarter:
+        return '🌗';
+      case MoonPhase.waningCrescent:
+        return '🌘';
+    }
+  }
+}
+
+/// One observation of a moon at a given date.
+class MoonObservation {
+  const MoonObservation({
+    required this.moon,
+    required this.phase,
+    required this.dayInCycle,
+  });
+
+  final MoonDef moon;
+  final MoonPhase phase;
+
+  /// Day-of-cycle, 0..periodDays-1. Useful for "🌒 2/8"-style UI.
+  final int dayInCycle;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MoonObservation &&
+          other.moon == moon &&
+          other.phase == phase &&
+          other.dayInCycle == dayInCycle;
+
+  @override
+  int get hashCode => Object.hash(moon, phase, dayInCycle);
+}

--- a/packages/calendar_engine/lib/src/world_date.dart
+++ b/packages/calendar_engine/lib/src/world_date.dart
@@ -1,0 +1,42 @@
+/// A date in an in-world calendar. All fields refer to the world's own
+/// calendar units, not Earth's. `monthIndex` is 0-based; `day` is 1-based.
+class WorldDate implements Comparable<WorldDate> {
+  const WorldDate({
+    required this.year,
+    required this.monthIndex,
+    required this.day,
+  });
+
+  final int year;
+  final int monthIndex;
+  final int day;
+
+  WorldDate copyWith({int? year, int? monthIndex, int? day}) => WorldDate(
+        year: year ?? this.year,
+        monthIndex: monthIndex ?? this.monthIndex,
+        day: day ?? this.day,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WorldDate &&
+          other.year == year &&
+          other.monthIndex == monthIndex &&
+          other.day == day;
+
+  @override
+  int get hashCode => Object.hash(year, monthIndex, day);
+
+  @override
+  int compareTo(WorldDate other) {
+    final byYear = year.compareTo(other.year);
+    if (byYear != 0) return byYear;
+    final byMonth = monthIndex.compareTo(other.monthIndex);
+    if (byMonth != 0) return byMonth;
+    return day.compareTo(other.day);
+  }
+
+  @override
+  String toString() => 'WorldDate($year, $monthIndex, $day)';
+}

--- a/packages/calendar_engine/pubspec.yaml
+++ b/packages/calendar_engine/pubspec.yaml
@@ -1,0 +1,11 @@
+name: calendar_engine
+description: Pure-Dart calendar math for fictional in-world calendars (D&D Calendar app).
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: ^3.10.7
+
+dev_dependencies:
+  test: ^1.25.0
+  lints: ^4.0.0

--- a/packages/calendar_engine/test/engine_test.dart
+++ b/packages/calendar_engine/test/engine_test.dart
@@ -1,0 +1,310 @@
+import 'package:calendar_engine/calendar_engine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CalendarConfig — base shape', () {
+    test('daysInYear sums all months without leap rule', () {
+      final c = _harptos();
+      expect(c.daysInYear(1), 360); // 12 * 30
+    });
+
+    test('daysInMonth honors leap rule on configured month', () {
+      final c = _harptos();
+      // leapRule: every 4 years, +1 day to month index 6
+      expect(c.daysInMonth(1, 6), 30);
+      expect(c.daysInMonth(4, 6), 31);
+      // Other months unaffected even on a leap year.
+      expect(c.daysInMonth(4, 0), 30);
+    });
+
+    test('daysInYear is +1 on a leap year', () {
+      final c = _harptos();
+      expect(c.daysInYear(4), 361);
+    });
+
+    test('isValidDate rejects out-of-range months/days', () {
+      final c = _harptos();
+      expect(c.isValidDate(1, 0, 1), isTrue);
+      expect(c.isValidDate(1, 0, 30), isTrue);
+      expect(c.isValidDate(1, 0, 31), isFalse); // base month is 30 days
+      expect(c.isValidDate(4, 6, 31), isTrue); // leap year extends month 6
+      expect(c.isValidDate(1, 12, 1), isFalse); // only 12 months (0..11)
+      expect(c.isValidDate(1, -1, 1), isFalse);
+    });
+  });
+
+  group('daysSinceEpoch', () {
+    test('epoch itself is 0', () {
+      final c = _harptos();
+      expect(daysSinceEpoch(const WorldDate(year: 1, monthIndex: 0, day: 1), c),
+          0);
+    });
+
+    test('counts within first month', () {
+      final c = _harptos();
+      expect(daysSinceEpoch(const WorldDate(year: 1, monthIndex: 0, day: 15), c),
+          14);
+    });
+
+    test('counts across months in the same year', () {
+      final c = _harptos();
+      // 1/2/1 = 30 days into year (skipped all of month 0)
+      expect(daysSinceEpoch(const WorldDate(year: 1, monthIndex: 1, day: 1), c),
+          30);
+    });
+
+    test('counts across years (no leap years in between)', () {
+      final c = _harptos();
+      // year 2, month 0, day 1 = exactly 360 days after epoch
+      expect(daysSinceEpoch(const WorldDate(year: 2, monthIndex: 0, day: 1), c),
+          360);
+    });
+
+    test('counts across a leap year', () {
+      final c = _harptos();
+      // year 5, month 0, day 1 = 360 + 360 + 360 + 361 = 1441
+      expect(daysSinceEpoch(const WorldDate(year: 5, monthIndex: 0, day: 1), c),
+          1441);
+    });
+
+    test('returns negative for dates before the epoch', () {
+      final c = _harptos();
+      // startYear is 1, so year 0 is the year *before* the epoch. Year 0 is
+      // a leap year under `year % 4 == 0`, so it has 361 days; the last day
+      // of year 0 is the day right before (1, 0, 1).
+      expect(daysSinceEpoch(const WorldDate(year: 0, monthIndex: 11, day: 30), c),
+          -1);
+      expect(daysSinceEpoch(const WorldDate(year: 0, monthIndex: 0, day: 1), c),
+          -361);
+    });
+  });
+
+  group('addDays', () {
+    test('zero is identity', () {
+      final c = _harptos();
+      const d = WorldDate(year: 3, monthIndex: 5, day: 12);
+      expect(addDays(d, 0, c), d);
+    });
+
+    test('overflows month boundary', () {
+      final c = _harptos();
+      const d = WorldDate(year: 1, monthIndex: 0, day: 28);
+      expect(addDays(d, 5, c), const WorldDate(year: 1, monthIndex: 1, day: 3));
+    });
+
+    test('overflows year boundary', () {
+      final c = _harptos();
+      const d = WorldDate(year: 1, monthIndex: 11, day: 28);
+      expect(addDays(d, 5, c), const WorldDate(year: 2, monthIndex: 0, day: 3));
+    });
+
+    test('skips into a leap year correctly', () {
+      final c = _harptos();
+      // year 4 month 6 has 31 days; year 4 month 7 day 1 = 30 + 30*5 + 31 = 211 days into year 4.
+      // year 4 month 6 day 30 + 1 day should give month 6 day 31, not month 7 day 1.
+      const d = WorldDate(year: 4, monthIndex: 6, day: 30);
+      expect(addDays(d, 1, c), const WorldDate(year: 4, monthIndex: 6, day: 31));
+      // and +2 should go to month 7 day 1.
+      expect(addDays(d, 2, c), const WorldDate(year: 4, monthIndex: 7, day: 1));
+    });
+
+    test('accepts negative offsets', () {
+      final c = _harptos();
+      const d = WorldDate(year: 2, monthIndex: 0, day: 5);
+      expect(addDays(d, -10, c), const WorldDate(year: 1, monthIndex: 11, day: 25));
+    });
+
+    test('round-trips with daysSinceEpoch', () {
+      final c = _harptos();
+      const d = WorldDate(year: 7, monthIndex: 4, day: 17);
+      final n = daysSinceEpoch(d, c);
+      expect(addDays(const WorldDate(year: 1, monthIndex: 0, day: 1), n, c), d);
+    });
+  });
+
+  group('daysBetween', () {
+    test('same date is 0', () {
+      final c = _harptos();
+      const d = WorldDate(year: 3, monthIndex: 5, day: 12);
+      expect(daysBetween(d, d, c), 0);
+    });
+
+    test('positive when b is after a', () {
+      final c = _harptos();
+      expect(
+        daysBetween(
+          const WorldDate(year: 1, monthIndex: 0, day: 1),
+          const WorldDate(year: 1, monthIndex: 0, day: 11),
+          c,
+        ),
+        10,
+      );
+    });
+
+    test('negative when b is before a', () {
+      final c = _harptos();
+      expect(
+        daysBetween(
+          const WorldDate(year: 1, monthIndex: 0, day: 11),
+          const WorldDate(year: 1, monthIndex: 0, day: 1),
+          c,
+        ),
+        -10,
+      );
+    });
+
+    test('counts a leap day when crossing one', () {
+      final c = _harptos();
+      // Year 4 has 361 days; year 1 to year 5 spans years 1,2,3,4 = 360+360+360+361 = 1441
+      expect(
+        daysBetween(
+          const WorldDate(year: 1, monthIndex: 0, day: 1),
+          const WorldDate(year: 5, monthIndex: 0, day: 1),
+          c,
+        ),
+        1441,
+      );
+    });
+  });
+
+  group('weekdayAt', () {
+    test('epoch is weekday 0', () {
+      final c = _harptos();
+      expect(weekdayAt(const WorldDate(year: 1, monthIndex: 0, day: 1), c), 0);
+    });
+
+    test('wraps after daysPerWeek', () {
+      final c = _harptos();
+      expect(weekdayAt(const WorldDate(year: 1, monthIndex: 0, day: 8), c), 0);
+      expect(weekdayAt(const WorldDate(year: 1, monthIndex: 0, day: 9), c), 1);
+    });
+
+    test('weekdayNameAt returns the configured name', () {
+      final c = _harptos();
+      expect(
+        weekdayNameAt(const WorldDate(year: 1, monthIndex: 0, day: 1), c),
+        'Sul',
+      );
+    });
+
+    test('handles negative dates correctly (no negative weekday)', () {
+      final c = _harptos();
+      // Day -1 should be weekday 6 (last weekday).
+      expect(
+        weekdayAt(const WorldDate(year: 0, monthIndex: 11, day: 30), c),
+        6,
+      );
+    });
+  });
+
+  group('moonPhaseAt', () {
+    test('newMoon at offset 0 on epoch', () {
+      final c = _harptos();
+      final selune = c.moons.first; // period 28, offset 0
+      final obs = moonPhaseAt(
+        const WorldDate(year: 1, monthIndex: 0, day: 1),
+        selune,
+        c,
+      );
+      expect(obs.phase, MoonPhase.newMoon);
+      expect(obs.dayInCycle, 0);
+    });
+
+    test('full moon halfway through cycle', () {
+      final c = _harptos();
+      final selune = c.moons.first;
+      // period 28 → fullMoon at indices 14..16 (since cycleDay*8 ~/ 28).
+      final obs = moonPhaseAt(
+        const WorldDate(year: 1, monthIndex: 0, day: 15),
+        selune,
+        c,
+      );
+      expect(obs.dayInCycle, 14);
+      expect(obs.phase, MoonPhase.fullMoon);
+    });
+
+    test('phase index honors moon offsetDays', () {
+      // Moon with periodDays 8 and offset 4 → on epoch it's already at cycleDay 4 (fullMoon).
+      final m = const MoonDef(
+        name: 'TestMoon',
+        periodDays: 8,
+        offsetDays: 4,
+        color: '#fff',
+      );
+      final c = _harptos();
+      final obs = moonPhaseAt(
+        const WorldDate(year: 1, monthIndex: 0, day: 1),
+        m,
+        c,
+      );
+      expect(obs.dayInCycle, 4);
+      expect(obs.phase, MoonPhase.fullMoon);
+    });
+
+    test('moonPhasesAt returns one observation per defined moon', () {
+      final c = _harptos();
+      final phases = moonPhasesAt(
+        const WorldDate(year: 1, monthIndex: 0, day: 1),
+        c,
+      );
+      expect(phases, hasLength(2));
+      expect(phases[0].moon.name, 'Selûne');
+      expect(phases[1].moon.name, 'Anadia');
+    });
+
+    test('phase advances as days advance', () {
+      final c = _harptos();
+      final selune = c.moons.first; // period 28
+      final phases = <MoonPhase>{};
+      for (var i = 0; i < 28; i++) {
+        phases.add(moonPhaseAt(
+          addDays(const WorldDate(year: 1, monthIndex: 0, day: 1), i, c),
+          selune,
+          c,
+        ).phase);
+      }
+      // Over a full cycle every one of the 8 phases must show up at least once.
+      expect(phases, hasLength(8));
+    });
+  });
+
+  group('formatDate', () {
+    test('renders day, month, year, epoch and weekday', () {
+      final c = _harptos();
+      expect(
+        formatDate(const WorldDate(year: 1, monthIndex: 0, day: 1), c),
+        '1 Hammer, 1 DR (Sul)',
+      );
+    });
+  });
+}
+
+/// A roughly Forgotten-Realms-style "Calendar of Harptos" fixture:
+/// 12 months × 30 days, 7-day week, +1 day to Flamerule (month 6) every
+/// 4 years, plus two moons (Selûne 28d, Anadia 90d).
+CalendarConfig _harptos() => const CalendarConfig(
+      daysPerWeek: 7,
+      weekdayNames: ['Sul', 'Mol', 'Zor', 'Wuk', 'Lok', 'Eko', 'Ano'],
+      months: [
+        MonthDef(name: 'Hammer', days: 30),
+        MonthDef(name: 'Alturiak', days: 30),
+        MonthDef(name: 'Ches', days: 30),
+        MonthDef(name: 'Tarsakh', days: 30),
+        MonthDef(name: 'Mirtul', days: 30),
+        MonthDef(name: 'Kythorn', days: 30),
+        MonthDef(name: 'Flamerule', days: 30),
+        MonthDef(name: 'Eleasis', days: 30),
+        MonthDef(name: 'Eleint', days: 30),
+        MonthDef(name: 'Marpenoth', days: 30),
+        MonthDef(name: 'Uktar', days: 30),
+        MonthDef(name: 'Nightal', days: 30),
+      ],
+      epochName: 'DR',
+      startYear: 1,
+      leapRule: LeapRule(everyNYears: 4, extraDayInMonthIndex: 6),
+      moons: [
+        MoonDef(name: 'Selûne', periodDays: 28, offsetDays: 0, color: '#ddddff'),
+        MoonDef(name: 'Anadia', periodDays: 90, offsetDays: 10, color: '#ffeecc'),
+      ],
+    );
+


### PR DESCRIPTION
## Summary

- New `packages/calendar_engine/` pure-Dart package — no Flutter, no Firebase, no I/O. Lives independently so the storage layer can swap without touching engine code (CONTEXT.md invariant).
- Public API kept small (deep module): `addDays`, `daysBetween`, `weekdayAt`, `moonPhasesAt`, `formatDate`, plus low-level `daysSinceEpoch` / `fromDaysSinceEpoch` / `moonPhaseAt`.
- Plain immutable Dart classes — chose not to pull in freezed for the engine itself. Persistence-facing freezed models will live in the app layer (S1) and convert to/from these types. Cleaner separation, no codegen in the engine.
- 30 unit tests cover everything in the issue's acceptance criteria.

## Test plan

- [x] `dart pub get` clean
- [x] `dart test` — 30/30 passing
- [x] `dart analyze` — no issues

Closes #3