### PR TITLE
S3: events CRUD + month/list calendar views

### DIFF
--- a/apps/dnd_calendar/lib/event_detail_screen.dart
+++ b/apps/dnd_calendar/lib/event_detail_screen.dart
@@ -1,0 +1,206 @@
+import 'package:calendar_engine/calendar_engine.dart' as engine;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_providers.dart';
+import 'event_edit_screen.dart';
+import 'event_providers.dart';
+import 'models/event.dart';
+import 'models/world.dart';
+import 'world_providers.dart';
+
+class EventDetailScreen extends ConsumerWidget {
+  const EventDetailScreen({
+    super.key,
+    required this.worldId,
+    required this.eventId,
+  });
+
+  final String worldId;
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final eventAsync =
+        ref.watch(eventProvider((worldId: worldId, eventId: eventId)));
+    final worldAsync = ref.watch(worldProvider(worldId));
+    final me = ref.watch(authStateChangesProvider).valueOrNull;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Event')),
+      body: eventAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (event) {
+          if (event == null) {
+            return const Center(child: Text('Event not found.'));
+          }
+          return worldAsync.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (e, _) => Center(child: Text('Error: $e')),
+            data: (world) {
+              if (world == null) {
+                return const Center(child: Text('World not found.'));
+              }
+              return _Body(
+                event: event,
+                world: world.calendar,
+                isOwner: me?.uid == world.ownerUid,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({
+    required this.event,
+    required this.world,
+    required this.isOwner,
+  });
+
+  final Event event;
+  final CalendarConfigData world;
+  final bool isOwner;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final c = world.toEngine();
+    final start = engine.formatDate(event.startDate.toEngine(), c);
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                event.title,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+            ),
+            _StatusBadge(status: event.status),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _kv(context, 'When', start),
+        if (event.registrationDeadline != event.startDate)
+          _kv(
+            context,
+            'Sign-up by',
+            engine.formatDate(event.registrationDeadline.toEngine(), c),
+          ),
+        _kv(
+          context,
+          'Capacity',
+          event.capacity == null ? 'unlimited' : '0 / ${event.capacity}',
+        ),
+        const SizedBox(height: 16),
+        if (event.description.isNotEmpty)
+          Text(event.description, style: const TextStyle(fontSize: 14)),
+        const SizedBox(height: 24),
+        if (isOwner) ...[
+          const Divider(),
+          Wrap(
+            spacing: 8,
+            children: [
+              OutlinedButton.icon(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => EventEditScreen(
+                      worldId: event.worldId,
+                      calendar: world,
+                      existing: event,
+                    ),
+                  ),
+                ),
+                icon: const Icon(Icons.edit),
+                label: const Text('Edit'),
+              ),
+              if (event.status != EventStatus.cancelled)
+                OutlinedButton.icon(
+                  onPressed: () => _confirmCancel(context, ref),
+                  icon: const Icon(Icons.cancel_outlined),
+                  label: const Text('Cancel event'),
+                ),
+            ],
+          ),
+        ],
+        const SizedBox(height: 24),
+        const Text(
+          'Player registration lands in S6.',
+          style: TextStyle(fontSize: 12),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _confirmCancel(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Cancel this event?'),
+        content: const Text(
+          'It will be marked as cancelled. Registrations stay visible.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Keep it'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Cancel event'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref
+        .read(eventRepositoryProvider)
+        .setStatus(event.worldId, event.id, EventStatus.cancelled);
+  }
+
+  Widget _kv(BuildContext context, String k, String v) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 100,
+              child:
+                  Text(k, style: TextStyle(color: Theme.of(context).hintColor)),
+            ),
+            Expanded(child: Text(v)),
+          ],
+        ),
+      );
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final EventStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (status) {
+      EventStatus.scheduled => ('Scheduled', Colors.blue),
+      EventStatus.completed => ('Completed', Colors.green),
+      EventStatus.cancelled => ('Cancelled', Colors.red),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(color: color, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/event_edit_screen.dart
+++ b/apps/dnd_calendar/lib/event_edit_screen.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_providers.dart';
+import 'event_providers.dart';
+import 'models/event.dart';
+import 'models/world.dart';
+import 'world_date_picker.dart';
+
+/// Single screen used for both event creation and editing. Pass [existing]
+/// to enter edit mode.
+class EventEditScreen extends ConsumerStatefulWidget {
+  const EventEditScreen({
+    super.key,
+    required this.worldId,
+    required this.calendar,
+    this.existing,
+  });
+
+  final String worldId;
+  final CalendarConfigData calendar;
+  final Event? existing;
+
+  @override
+  ConsumerState<EventEditScreen> createState() => _EventEditScreenState();
+}
+
+class _EventEditScreenState extends ConsumerState<EventEditScreen> {
+  final _titleCtl = TextEditingController();
+  final _descCtl = TextEditingController();
+  final _capacityCtl = TextEditingController();
+  late WorldDateData _startDate;
+  WorldDateData? _deadline;
+  bool _busy = false;
+  String? _error;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    if (e != null) {
+      _titleCtl.text = e.title;
+      _descCtl.text = e.description;
+      _capacityCtl.text = e.capacity?.toString() ?? '';
+      _startDate = e.startDate;
+      _deadline = e.registrationDeadline == e.startDate ? null : e.registrationDeadline;
+    } else {
+      _startDate = widget.calendar.currentDate;
+      _deadline = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtl.dispose();
+    _descCtl.dispose();
+    _capacityCtl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final title = _titleCtl.text.trim();
+    if (title.isEmpty) {
+      setState(() => _error = 'Title is required');
+      return;
+    }
+    final user = ref.read(authStateChangesProvider).valueOrNull;
+    if (user == null) {
+      setState(() => _error = 'Not signed in');
+      return;
+    }
+    final capacity = _capacityCtl.text.trim().isEmpty
+        ? null
+        : int.tryParse(_capacityCtl.text.trim());
+    if (_capacityCtl.text.trim().isNotEmpty && (capacity == null || capacity < 1)) {
+      setState(() => _error = 'Capacity must be a positive number');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final repo = ref.read(eventRepositoryProvider);
+      final event = (widget.existing ??
+              Event(
+                id: '',
+                worldId: widget.worldId,
+                title: title,
+                startDate: _startDate,
+                registrationDeadline: _deadline ?? _startDate,
+                createdByUid: user.uid,
+              ))
+          .copyWith(
+        title: title,
+        description: _descCtl.text.trim(),
+        startDate: _startDate,
+        registrationDeadline: _deadline ?? _startDate,
+        capacity: capacity,
+      );
+      if (_isEdit) {
+        await repo.updateEvent(event);
+      } else {
+        await repo.createEvent(event);
+      }
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEdit ? 'Edit event' : 'New event'),
+        actions: [
+          if (_busy)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+            )
+          else
+            TextButton(
+              onPressed: _save,
+              child: const Text('Save', style: TextStyle(color: Colors.white)),
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+          TextField(
+            controller: _titleCtl,
+            decoration: const InputDecoration(labelText: 'Title'),
+            textCapitalization: TextCapitalization.sentences,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _descCtl,
+            decoration: const InputDecoration(
+              labelText: 'Description',
+              hintText: 'Plain text only — no markdown for MVP',
+            ),
+            maxLines: 4,
+          ),
+          const SizedBox(height: 16),
+          WorldDatePicker(
+            label: 'Start date',
+            calendar: widget.calendar,
+            initial: _startDate,
+            onChanged: (d) => setState(() => _startDate = d),
+          ),
+          const SizedBox(height: 16),
+          WorldDatePicker(
+            label: 'Registration deadline (default = start date)',
+            calendar: widget.calendar,
+            initial: _deadline ?? _startDate,
+            onChanged: (d) => setState(() => _deadline = d),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _capacityCtl,
+            decoration: const InputDecoration(
+              labelText: 'Capacity',
+              hintText: 'Leave blank for unlimited',
+            ),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/event_providers.dart
+++ b/apps/dnd_calendar/lib/event_providers.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'event_repository.dart';
+import 'models/event.dart';
+import 'world_providers.dart';
+
+final eventRepositoryProvider = Provider<EventRepository>(
+  (ref) => EventRepository(ref.watch(firestoreProvider)),
+);
+
+/// Stream of all events for a world, ordered by startDate ascending.
+final eventsProvider = StreamProvider.family<List<Event>, String>((ref, worldId) {
+  return ref.watch(eventRepositoryProvider).watchEvents(worldId);
+});
+
+/// One event by id.
+final eventProvider =
+    StreamProvider.family<Event?, ({String worldId, String eventId})>(
+  (ref, k) =>
+      ref.watch(eventRepositoryProvider).watchEvent(k.worldId, k.eventId),
+);

--- a/apps/dnd_calendar/lib/event_repository.dart
+++ b/apps/dnd_calendar/lib/event_repository.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'models/event.dart';
+
+class EventRepository {
+  EventRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  CollectionReference<Map<String, dynamic>> _events(String worldId) =>
+      _db.collection('worlds').doc(worldId).collection('events');
+
+  Stream<List<Event>> watchEvents(String worldId) {
+    return _events(worldId)
+        .orderBy('startDate.year')
+        .orderBy('startDate.monthIndex')
+        .orderBy('startDate.day')
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => Event.fromFirestore(d, worldId)).toList());
+  }
+
+  Stream<Event?> watchEvent(String worldId, String eventId) {
+    return _events(worldId).doc(eventId).snapshots().map(
+          (d) => d.exists ? Event.fromFirestore(d, worldId) : null,
+        );
+  }
+
+  Future<String> createEvent(Event event) async {
+    final doc = _events(event.worldId).doc();
+    await doc.set({
+      ...event.toFirestore(),
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    return doc.id;
+  }
+
+  Future<void> updateEvent(Event event) async {
+    await _events(event.worldId).doc(event.id).update(event.toFirestore());
+  }
+
+  Future<void> setStatus(
+    String worldId,
+    String eventId,
+    EventStatus status,
+  ) async {
+    await _events(worldId).doc(eventId).update({'status': status.name});
+  }
+}

--- a/apps/dnd_calendar/lib/events_section.dart
+++ b/apps/dnd_calendar/lib/events_section.dart
@@ -1,0 +1,476 @@
+import 'package:calendar_engine/calendar_engine.dart' as engine;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_providers.dart';
+import 'event_detail_screen.dart';
+import 'event_edit_screen.dart';
+import 'event_providers.dart';
+import 'models/event.dart';
+import 'models/world.dart';
+import 'world_providers.dart';
+
+enum _ViewMode { list, month }
+
+/// Events tab inside the world detail screen. Owner can create events;
+/// everyone can view. Toggle between chronological list and one-month grid.
+class EventsSection extends ConsumerStatefulWidget {
+  const EventsSection({
+    super.key,
+    required this.worldId,
+    required this.calendar,
+  });
+
+  final String worldId;
+  final CalendarConfigData calendar;
+
+  @override
+  ConsumerState<EventsSection> createState() => _EventsSectionState();
+}
+
+class _EventsSectionState extends ConsumerState<EventsSection> {
+  _ViewMode _mode = _ViewMode.list;
+  late int _viewYear;
+  late int _viewMonth;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewYear = widget.calendar.currentDate.year;
+    _viewMonth = widget.calendar.currentDate.monthIndex;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final eventsAsync = ref.watch(eventsProvider(widget.worldId));
+    final me = ref.watch(authStateChangesProvider).valueOrNull;
+    final worldAsync = ref.watch(worldProvider(widget.worldId));
+    final isOwner = worldAsync.valueOrNull?.ownerUid == me?.uid;
+
+    return Scaffold(
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: SegmentedButton<_ViewMode>(
+              segments: const [
+                ButtonSegment(
+                  value: _ViewMode.list,
+                  label: Text('List'),
+                  icon: Icon(Icons.list),
+                ),
+                ButtonSegment(
+                  value: _ViewMode.month,
+                  label: Text('Month'),
+                  icon: Icon(Icons.calendar_view_month),
+                ),
+              ],
+              selected: {_mode},
+              onSelectionChanged: (s) => setState(() => _mode = s.first),
+            ),
+          ),
+          Expanded(
+            child: eventsAsync.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+              data: (events) {
+                if (events.isEmpty) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Text(
+                        'No events yet.',
+                        style: TextStyle(fontSize: 14),
+                      ),
+                    ),
+                  );
+                }
+                return _mode == _ViewMode.list
+                    ? _ListView(
+                        events: events,
+                        worldId: widget.worldId,
+                        calendar: widget.calendar,
+                      )
+                    : _MonthView(
+                        events: events,
+                        worldId: widget.worldId,
+                        calendar: widget.calendar,
+                        year: _viewYear,
+                        monthIndex: _viewMonth,
+                        onPrev: _prevMonth,
+                        onNext: _nextMonth,
+                      );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: isOwner
+          ? FloatingActionButton.extended(
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => EventEditScreen(
+                    worldId: widget.worldId,
+                    calendar: widget.calendar,
+                  ),
+                ),
+              ),
+              icon: const Icon(Icons.add),
+              label: const Text('New event'),
+            )
+          : null,
+    );
+  }
+
+  void _prevMonth() {
+    setState(() {
+      if (_viewMonth == 0) {
+        _viewMonth = widget.calendar.months.length - 1;
+        _viewYear -= 1;
+      } else {
+        _viewMonth -= 1;
+      }
+    });
+  }
+
+  void _nextMonth() {
+    setState(() {
+      if (_viewMonth == widget.calendar.months.length - 1) {
+        _viewMonth = 0;
+        _viewYear += 1;
+      } else {
+        _viewMonth += 1;
+      }
+    });
+  }
+}
+
+class _ListView extends StatelessWidget {
+  const _ListView({
+    required this.events,
+    required this.worldId,
+    required this.calendar,
+  });
+
+  final List<Event> events;
+  final String worldId;
+  final CalendarConfigData calendar;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = calendar.toEngine();
+    final today = calendar.currentDate.toEngine();
+    final upcoming = <Event>[];
+    final past = <Event>[];
+    for (final e in events) {
+      final start = e.startDate.toEngine();
+      if (start.compareTo(today) >= 0) {
+        upcoming.add(e);
+      } else {
+        past.add(e);
+      }
+    }
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 96),
+      children: [
+        if (upcoming.isNotEmpty) ...[
+          const _SectionHeader('Upcoming'),
+          for (final e in upcoming)
+            _EventTile(event: e, calendar: c, worldId: worldId),
+        ],
+        if (past.isNotEmpty) ...[
+          const _SectionHeader('Past'),
+          for (final e in past.reversed)
+            _EventTile(event: e, calendar: c, worldId: worldId, dim: true),
+        ],
+      ],
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        text.toUpperCase(),
+        style: TextStyle(
+          fontSize: 12,
+          letterSpacing: 1,
+          color: Theme.of(context).hintColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _EventTile extends StatelessWidget {
+  const _EventTile({
+    required this.event,
+    required this.calendar,
+    required this.worldId,
+    this.dim = false,
+  });
+
+  final Event event;
+  final engine.CalendarConfig calendar;
+  final String worldId;
+  final bool dim;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = engine.formatDate(event.startDate.toEngine(), calendar);
+    final cancelled = event.status == EventStatus.cancelled;
+    return ListTile(
+      leading: Icon(
+        cancelled ? Icons.cancel_outlined : Icons.event,
+        color: cancelled ? Colors.red : null,
+      ),
+      title: Text(
+        event.title,
+        style: TextStyle(
+          decoration: cancelled ? TextDecoration.lineThrough : null,
+          color: dim ? Theme.of(context).hintColor : null,
+        ),
+      ),
+      subtitle: Text(start),
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => EventDetailScreen(
+            worldId: worldId,
+            eventId: event.id,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MonthView extends StatelessWidget {
+  const _MonthView({
+    required this.events,
+    required this.worldId,
+    required this.calendar,
+    required this.year,
+    required this.monthIndex,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final List<Event> events;
+  final String worldId;
+  final CalendarConfigData calendar;
+  final int year;
+  final int monthIndex;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = calendar.toEngine();
+    final monthName = calendar.months[monthIndex].name;
+    final daysInMonth = c.daysInMonth(year, monthIndex);
+    final firstWeekday = engine.weekdayAt(
+      engine.WorldDate(year: year, monthIndex: monthIndex, day: 1),
+      c,
+    );
+    // Group events by day-of-month for this (year, monthIndex).
+    final byDay = <int, List<Event>>{};
+    for (final e in events) {
+      final d = e.startDate;
+      if (d.year == year && d.monthIndex == monthIndex) {
+        byDay.putIfAbsent(d.day, () => []).add(e);
+      }
+    }
+    final cells = firstWeekday + daysInMonth;
+    final rows = (cells / calendar.daysPerWeek).ceil();
+    final today = calendar.currentDate;
+    final isCurrentMonth = today.year == year && today.monthIndex == monthIndex;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            children: [
+              IconButton(onPressed: onPrev, icon: const Icon(Icons.chevron_left)),
+              Expanded(
+                child: Center(
+                  child: Text(
+                    '$monthName, $year ${calendar.epochName}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+              ),
+              IconButton(
+                  onPressed: onNext, icon: const Icon(Icons.chevron_right)),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            children: [
+              for (final w in calendar.weekdayNames)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      w.length > 3 ? w.substring(0, 3) : w,
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: Theme.of(context).hintColor,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.fromLTRB(4, 0, 4, 96),
+            itemCount: rows,
+            itemBuilder: (_, row) {
+              return AspectRatio(
+                aspectRatio: calendar.daysPerWeek.toDouble() / 1.0,
+                child: Row(
+                  children: [
+                    for (var col = 0; col < calendar.daysPerWeek; col++)
+                      Expanded(
+                        child: _DayCell(
+                          dayNumber:
+                              row * calendar.daysPerWeek + col - firstWeekday + 1,
+                          maxDay: daysInMonth,
+                          events: byDay,
+                          isToday: isCurrentMonth,
+                          today: today.day,
+                          worldId: worldId,
+                          calendar: calendar,
+                        ),
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DayCell extends StatelessWidget {
+  const _DayCell({
+    required this.dayNumber,
+    required this.maxDay,
+    required this.events,
+    required this.isToday,
+    required this.today,
+    required this.worldId,
+    required this.calendar,
+  });
+
+  final int dayNumber;
+  final int maxDay;
+  final Map<int, List<Event>> events;
+  final bool isToday;
+  final int today;
+  final String worldId;
+  final CalendarConfigData calendar;
+
+  @override
+  Widget build(BuildContext context) {
+    if (dayNumber < 1 || dayNumber > maxDay) {
+      return const SizedBox.shrink();
+    }
+    final dayEvents = events[dayNumber] ?? const <Event>[];
+    final highlight = isToday && dayNumber == today;
+    return InkWell(
+      onTap: dayEvents.isEmpty
+          ? null
+          : () => _showDayEvents(context, dayEvents),
+      child: Container(
+        margin: const EdgeInsets.all(2),
+        padding: const EdgeInsets.all(4),
+        decoration: BoxDecoration(
+          border: Border.all(color: Theme.of(context).dividerColor),
+          color: highlight
+              ? Theme.of(context).colorScheme.primaryContainer
+              : null,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '$dayNumber',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: highlight ? FontWeight.bold : null,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Wrap(
+              spacing: 2,
+              children: [
+                for (final e in dayEvents.take(3))
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: BoxDecoration(
+                      color: e.status == EventStatus.cancelled
+                          ? Colors.red
+                          : Colors.blue,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                if (dayEvents.length > 3)
+                  Text(
+                    '+${dayEvents.length - 3}',
+                    style: const TextStyle(fontSize: 9),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showDayEvents(BuildContext context, List<Event> dayEvents) {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final e in dayEvents)
+              ListTile(
+                title: Text(e.title),
+                subtitle: e.status == EventStatus.cancelled
+                    ? const Text('Cancelled')
+                    : null,
+                onTap: () {
+                  Navigator.of(context).pop();
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => EventDetailScreen(
+                        worldId: worldId,
+                        eventId: e.id,
+                      ),
+                    ),
+                  );
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/models/event.dart
+++ b/apps/dnd_calendar/lib/models/event.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'world.dart';
+
+part 'event.freezed.dart';
+part 'event.g.dart';
+
+enum EventStatus { scheduled, completed, cancelled }
+
+@freezed
+class Event with _$Event {
+  const Event._();
+  const factory Event({
+    required String id,
+    required String worldId,
+    required String title,
+    @Default('') String description,
+    required WorldDateData startDate,
+    WorldDateData? endDate,
+    int? capacity,
+    required WorldDateData registrationDeadline,
+    @Default(EventStatus.scheduled) EventStatus status,
+    required String createdByUid,
+    @TimestampConverter() DateTime? createdAt,
+  }) = _Event;
+  factory Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
+
+  factory Event.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+    String worldId,
+  ) {
+    final data = doc.data()!;
+    return Event.fromJson({...data, 'id': doc.id, 'worldId': worldId});
+  }
+
+  Map<String, dynamic> toFirestore() {
+    final j = toJson();
+    j.remove('id');
+    j.remove('worldId');
+    return j;
+  }
+}

--- a/apps/dnd_calendar/lib/world_date_picker.dart
+++ b/apps/dnd_calendar/lib/world_date_picker.dart
@@ -1,0 +1,153 @@
+import 'package:calendar_engine/calendar_engine.dart' as engine;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'models/world.dart';
+
+/// Pick a [WorldDateData] using the world's own calendar config (custom
+/// weekday/month/day vocabulary). The standard Material DatePicker is
+/// useless here because it assumes Earth-Gregorian.
+class WorldDatePicker extends StatefulWidget {
+  const WorldDatePicker({
+    super.key,
+    required this.calendar,
+    required this.initial,
+    required this.onChanged,
+    this.label,
+  });
+
+  final CalendarConfigData calendar;
+  final WorldDateData initial;
+  final ValueChanged<WorldDateData> onChanged;
+  final String? label;
+
+  @override
+  State<WorldDatePicker> createState() => _WorldDatePickerState();
+}
+
+class _WorldDatePickerState extends State<WorldDatePicker> {
+  late int _year;
+  late int _monthIndex;
+  late int _day;
+  late TextEditingController _yearCtl;
+
+  @override
+  void initState() {
+    super.initState();
+    _year = widget.initial.year;
+    _monthIndex = widget.initial.monthIndex;
+    _day = widget.initial.day;
+    _yearCtl = TextEditingController(text: _year.toString());
+  }
+
+  @override
+  void dispose() {
+    _yearCtl.dispose();
+    super.dispose();
+  }
+
+  void _emit() {
+    widget.onChanged(
+      WorldDateData(year: _year, monthIndex: _monthIndex, day: _day),
+    );
+  }
+
+  int _daysInMonth() {
+    final c = widget.calendar.toEngine();
+    return c.daysInMonth(_year, _monthIndex);
+  }
+
+  String _weekdayName() {
+    final c = widget.calendar.toEngine();
+    final d = engine.WorldDate(year: _year, monthIndex: _monthIndex, day: _day);
+    return engine.weekdayNameAt(d, c);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final months = widget.calendar.months;
+    final monthIndex = _monthIndex.clamp(0, months.length - 1);
+    final daysIn = _daysInMonth();
+    final clampedDay = _day.clamp(1, daysIn);
+    if (clampedDay != _day) {
+      _day = clampedDay;
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.label != null) ...[
+          Text(widget.label!, style: const TextStyle(fontSize: 12)),
+          const SizedBox(height: 4),
+        ],
+        Row(
+          children: [
+            // Year
+            SizedBox(
+              width: 96,
+              child: TextField(
+                controller: _yearCtl,
+                decoration: const InputDecoration(labelText: 'Year'),
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                onChanged: (v) {
+                  final y = int.tryParse(v);
+                  if (y != null) {
+                    setState(() => _year = y);
+                    _emit();
+                  }
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            // Month
+            Expanded(
+              child: DropdownButtonFormField<int>(
+                initialValue: monthIndex,
+                decoration: const InputDecoration(labelText: 'Month'),
+                items: [
+                  for (var i = 0; i < months.length; i++)
+                    DropdownMenuItem(value: i, child: Text(months[i].name)),
+                ],
+                onChanged: (v) {
+                  if (v != null) {
+                    setState(() => _monthIndex = v);
+                    _emit();
+                  }
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            // Day
+            SizedBox(
+              width: 84,
+              child: DropdownButtonFormField<int>(
+                initialValue: _day,
+                decoration: const InputDecoration(labelText: 'Day'),
+                items: [
+                  for (var d = 1; d <= daysIn; d++)
+                    DropdownMenuItem(value: d, child: Text('$d')),
+                ],
+                onChanged: (v) {
+                  if (v != null) {
+                    setState(() => _day = v);
+                    _emit();
+                  }
+                },
+              ),
+            ),
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            _weekdayName(),
+            style: TextStyle(
+              fontSize: 12,
+              color: Theme.of(context).hintColor,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/world_detail_screen.dart
+++ b/apps/dnd_calendar/lib/world_detail_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth_providers.dart';
 import 'calendar_config_edit_screen.dart';
+import 'events_section.dart';
+import 'models/world.dart';
 import 'world_providers.dart';
 
 class WorldDetailScreen extends ConsumerWidget {
@@ -17,81 +19,112 @@ class WorldDetailScreen extends ConsumerWidget {
     final world = ref.watch(worldProvider(worldId));
     final me = ref.watch(authStateChangesProvider).valueOrNull;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('World')),
-      body: world.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
-        data: (w) {
-          if (w == null) {
-            return const Center(child: Text('World not found.'));
-          }
-          final isOwner = me?.uid == w.ownerUid;
-          final cal = w.calendar.toEngine();
-          final today = w.calendar.currentDate.toEngine();
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: [
-              Text(w.name, style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: 8),
-              if (isOwner)
-                _OwnerJoinCode(joinCode: w.joinCode)
-              else
-                Text('Role: player', style: Theme.of(context).textTheme.bodySmall),
-              const Divider(height: 32),
-              Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      'Calendar',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                  if (isOwner)
-                    TextButton.icon(
-                      onPressed: () => Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) => CalendarConfigEditScreen(
-                            worldId: w.id,
-                            initial: w.calendar,
-                          ),
-                        ),
-                      ),
-                      icon: const Icon(Icons.edit),
-                      label: const Text('Edit'),
-                    ),
+    return world.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => Scaffold(
+        body: Center(child: Text('Error: $e')),
+      ),
+      data: (w) {
+        if (w == null) {
+          return const Scaffold(
+            body: Center(child: Text('World not found.')),
+          );
+        }
+        final isOwner = me?.uid == w.ownerUid;
+        return DefaultTabController(
+          length: 2,
+          child: Scaffold(
+            appBar: AppBar(
+              title: Text(w.name),
+              bottom: const TabBar(
+                tabs: [
+                  Tab(icon: Icon(Icons.castle), text: 'Overview'),
+                  Tab(icon: Icon(Icons.event), text: 'Events'),
                 ],
               ),
-              const SizedBox(height: 8),
-              _kv(context, 'Today', engine.formatDate(today, cal)),
-              _kv(context, 'Week length', '${cal.daysPerWeek} days'),
-              _kv(
-                context,
-                'Year length',
-                '${cal.daysInYear(today.year)} days '
-                    '(${cal.months.length} months)',
+            ),
+            body: TabBarView(
+              children: [
+                _OverviewTab(world: w, isOwner: isOwner),
+                EventsSection(worldId: w.id, calendar: w.calendar),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({required this.world, required this.isOwner});
+
+  final World world;
+  final bool isOwner;
+
+  @override
+  Widget build(BuildContext context) {
+    final cal = world.calendar.toEngine();
+    final today = world.calendar.currentDate.toEngine();
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        if (isOwner)
+          _OwnerJoinCode(joinCode: world.joinCode)
+        else
+          Text('Role: player', style: Theme.of(context).textTheme.bodySmall),
+        const Divider(height: 32),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Calendar',
+                style: Theme.of(context).textTheme.titleMedium,
               ),
-              _kv(context, 'Epoch', cal.epochName),
-              _kv(context, 'Moons', cal.moons.map((m) => m.name).join(', ')),
-              if (cal.leapRule != null)
-                _kv(
-                  context,
-                  'Leap rule',
-                  'Every ${cal.leapRule!.everyNYears} years +1 day',
-                )
-              else
-                _kv(context, 'Leap rule', 'none'),
-              const SizedBox(height: 32),
-              const Divider(),
-              const Text(
-                'Events, characters, and quest registration land in later '
-                'slices.',
-                style: TextStyle(fontSize: 12),
+            ),
+            if (isOwner)
+              TextButton.icon(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => CalendarConfigEditScreen(
+                      worldId: world.id,
+                      initial: world.calendar,
+                    ),
+                  ),
+                ),
+                icon: const Icon(Icons.edit),
+                label: const Text('Edit'),
               ),
-            ],
-          );
-        },
-      ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        _kv(context, 'Today', engine.formatDate(today, cal)),
+        _kv(context, 'Week length', '${cal.daysPerWeek} days'),
+        _kv(
+          context,
+          'Year length',
+          '${cal.daysInYear(today.year)} days '
+              '(${cal.months.length} months)',
+        ),
+        _kv(context, 'Epoch', cal.epochName),
+        _kv(context, 'Moons', cal.moons.map((m) => m.name).join(', ')),
+        if (cal.leapRule != null)
+          _kv(
+            context,
+            'Leap rule',
+            'Every ${cal.leapRule!.everyNYears} years +1 day',
+          )
+        else
+          _kv(context, 'Leap rule', 'none'),
+        const SizedBox(height: 32),
+        const Divider(),
+        const Text(
+          'Characters and quest registration land in later slices.',
+          style: TextStyle(fontSize: 12),
+        ),
+      ],
     );
   }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -31,8 +31,29 @@ service cloud.firestore {
         && request.resource.data.ownerUid == resource.data.ownerUid;
       allow delete: if isOwner(worldId);
 
-      // Subcollections — open placeholders. Real rules land in S3/S4/S5/S6.
-      match /{document=**} {
+      // Events — read for any signed-in (S4 narrows to members + owner),
+      // write only by world owner. createdByUid must match auth.uid on
+      // create and stay immutable on update.
+      match /events/{eventId} {
+        allow read: if signedIn();
+        allow create: if isOwner(worldId)
+          && request.resource.data.createdByUid == request.auth.uid;
+        allow update: if isOwner(worldId)
+          && request.resource.data.createdByUid == resource.data.createdByUid;
+        allow delete: if isOwner(worldId);
+
+        // Registrations — placeholder until S6.
+        match /registrations/{regUid} {
+          allow read, write: if signedIn();
+        }
+      }
+
+      // Other subcollections (members, characters) — placeholders until
+      // S4/S5 land their real rules.
+      match /members/{memberUid} {
+        allow read, write: if signedIn();
+      }
+      match /characters/{charId} {
         allow read, write: if signedIn();
       }
     }


### PR DESCRIPTION
## Summary

DM creates / edits / cancels events on the world calendar. All members read. Two switchable views inside a new "Events" tab on the world detail screen.

## What it adds

- `models/event.dart` — `Event` freezed with EventStatus enum
- `event_repository.dart` — CRUD on `worlds/{w}/events`, ordered by startDate y/m/d
- `event_providers.dart` — `eventsProvider(worldId)`, `eventProvider({worldId, eventId})`
- `world_date_picker.dart` — pick a `WorldDate` against the world's *own* calendar (year stepper + month dropdown + day dropdown with weekday preview)
- `event_edit_screen.dart` — single screen for create + edit
- `event_detail_screen.dart` — title, status badge, when, sign-up deadline, capacity, description; owner Edit + Cancel
- `events_section.dart` — list/month toggle, FAB to create (owner only)
  - List splits Upcoming / Past on world's `currentDate`
  - Month view renders an in-world month grid via `engine.weekdayAt`, today highlighted, day cells show event dots, tap → bottom sheet
- `world_detail_screen.dart` restructured to `DefaultTabController` with Overview + Events tabs
- `firestore.rules`: events read by any signed-in, create/update/delete by world owner; `createdByUid` immutable on update

## Out of scope (per CONTEXT.md)

- Multi-day event UI — `endDate` is in the model but the UI treats events as single-day. Lands in S7.
- Capacity is displayed but not enforced at registration (registration itself lands in S6).

## Test plan

- [x] `dart analyze` clean
- [x] `dart run build_runner build` succeeds
- [ ] Manual on emulator: DM creates event → appears in both views → edit → cancel → status badge updates
- [ ] Month view: today's cell highlighted, dot per event, prev/next navigation works across year boundary
- [ ] After deploying updated rules: non-owner cannot create/edit events

Closes #5