### PR TITLE
S4: join-by-code flow + members + tightened rules

### DIFF
--- a/apps/dnd_calendar/lib/join_world_screen.dart
+++ b/apps/dnd_calendar/lib/join_world_screen.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_providers.dart';
+import 'world_detail_screen.dart';
+import 'world_providers.dart';
+
+class JoinWorldScreen extends ConsumerStatefulWidget {
+  const JoinWorldScreen({super.key});
+
+  @override
+  ConsumerState<JoinWorldScreen> createState() => _JoinWorldScreenState();
+}
+
+class _JoinWorldScreenState extends ConsumerState<JoinWorldScreen> {
+  final _codeCtl = TextEditingController();
+  bool _busy = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _codeCtl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _join() async {
+    final code = _codeCtl.text.trim().toUpperCase();
+    if (code.length != 6) {
+      setState(() => _error = 'Join code is 6 characters');
+      return;
+    }
+    final user = ref.read(authStateChangesProvider).valueOrNull;
+    if (user == null) {
+      setState(() => _error = 'Not signed in');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final repo = ref.read(worldRepositoryProvider);
+      final worldId = await repo.resolveJoinCode(code);
+      if (worldId == null) {
+        setState(() => _error = 'No world matches that code');
+        return;
+      }
+      // Idempotent — owner re-joining or already-member re-joining is fine.
+      await repo.joinWorld(worldId: worldId, uid: user.uid);
+      if (mounted) _replaceWith(worldId);
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _replaceWith(String worldId) {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => WorldDetailScreen(worldId: worldId)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Join a world')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _codeCtl,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Join code',
+                hintText: '6 letters / digits',
+                counterText: '',
+              ),
+              maxLength: 6,
+              textCapitalization: TextCapitalization.characters,
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[A-Za-z0-9]')),
+                _UpperCaseFormatter(),
+              ],
+              style: const TextStyle(
+                fontSize: 24,
+                fontFamily: 'monospace',
+                letterSpacing: 6,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: _busy ? null : _join,
+              icon: const Icon(Icons.login),
+              label: Text(_busy ? 'Joining…' : 'Join world'),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 16),
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            ],
+            const SizedBox(height: 24),
+            Text(
+              'Ask the DM for the world code. After joining, the world '
+              'shows up in your list.',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).hintColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UpperCaseFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    return newValue.copyWith(text: newValue.text.toUpperCase());
+  }
+}

--- a/apps/dnd_calendar/lib/models/member.dart
+++ b/apps/dnd_calendar/lib/models/member.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'world.dart';
+
+part 'member.freezed.dart';
+part 'member.g.dart';
+
+enum MemberRole { dm, player }
+
+/// One person's membership in a world. Owner is implicit and not stored
+/// here — derived from `worlds/{w}.ownerUid`.
+@freezed
+class Member with _$Member {
+  const Member._();
+  const factory Member({
+    required String uid,
+    required String worldId,
+    @Default(MemberRole.player) MemberRole role,
+    @TimestampConverter() DateTime? joinedAt,
+  }) = _Member;
+  factory Member.fromJson(Map<String, dynamic> json) => _$MemberFromJson(json);
+
+  factory Member.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+    String worldId,
+  ) {
+    final data = doc.data()!;
+    return Member.fromJson({...data, 'uid': doc.id, 'worldId': worldId});
+  }
+}

--- a/apps/dnd_calendar/lib/world_list_screen.dart
+++ b/apps/dnd_calendar/lib/world_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth_providers.dart';
 import 'create_world_screen.dart';
+import 'join_world_screen.dart';
 import 'models/world.dart';
 import 'world_detail_screen.dart';
 import 'world_providers.dart';
@@ -20,6 +21,13 @@ class WorldListScreen extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('D&D Calendar'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.login),
+            tooltip: 'Join with code',
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const JoinWorldScreen()),
+            ),
+          ),
           IconButton(
             icon: const Icon(Icons.logout),
             tooltip: 'Sign out',
@@ -41,10 +49,20 @@ class WorldListScreen extends ConsumerWidget {
           if (list.isEmpty) {
             return _EmptyState(name: name);
           }
-          return ListView.separated(
-            itemCount: list.length,
-            separatorBuilder: (_, _) => const Divider(height: 0),
-            itemBuilder: (_, i) => _WorldTile(world: list[i]),
+          final myUid = user?.uid;
+          final dmd = list.where((w) => w.ownerUid == myUid).toList();
+          final joined = list.where((w) => w.ownerUid != myUid).toList();
+          return ListView(
+            children: [
+              if (dmd.isNotEmpty) ...[
+                const _SectionHeader('You DM'),
+                for (final w in dmd) _WorldTile(world: w, isOwner: true),
+              ],
+              if (joined.isNotEmpty) ...[
+                const _SectionHeader('You joined'),
+                for (final w in joined) _WorldTile(world: w, isOwner: false),
+              ],
+            ],
           );
         },
       ),
@@ -52,10 +70,32 @@ class WorldListScreen extends ConsumerWidget {
   }
 }
 
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        text.toUpperCase(),
+        style: TextStyle(
+          fontSize: 12,
+          letterSpacing: 1,
+          color: Theme.of(context).hintColor,
+        ),
+      ),
+    );
+  }
+}
+
 class _WorldTile extends StatelessWidget {
-  const _WorldTile({required this.world});
+  const _WorldTile({required this.world, required this.isOwner});
 
   final World world;
+  final bool isOwner;
 
   @override
   Widget build(BuildContext context) {
@@ -64,7 +104,7 @@ class _WorldTile extends StatelessWidget {
         '${cal.daysPerWeek}-day week · '
         '${cal.moons.length} moon(s)';
     return ListTile(
-      leading: const Icon(Icons.castle),
+      leading: Icon(isOwner ? Icons.shield : Icons.person),
       title: Text(world.name),
       subtitle: Text(subtitle),
       trailing: const Icon(Icons.chevron_right),
@@ -98,7 +138,8 @@ class _EmptyState extends StatelessWidget {
             ),
             const SizedBox(height: 8),
             const Text(
-              'No worlds yet. Tap "New world" to create one.',
+              'No worlds yet. Create one with the + button, or use the '
+              'login icon in the app bar to join with a code.',
               textAlign: TextAlign.center,
             ),
           ],

--- a/apps/dnd_calendar/lib/world_providers.dart
+++ b/apps/dnd_calendar/lib/world_providers.dart
@@ -14,13 +14,53 @@ final worldRepositoryProvider = Provider<WorldRepository>(
 );
 
 /// Worlds owned by the signed-in user. Empty list while signed out.
-final myWorldsProvider = StreamProvider<List<World>>((ref) {
+final ownedWorldsProvider = StreamProvider<List<World>>((ref) {
   final user = ref.watch(authStateChangesProvider).valueOrNull;
   if (user == null) return Stream.value(<World>[]);
-  return ref.watch(worldRepositoryProvider).watchWorldsForUser(user.uid);
+  return ref.watch(worldRepositoryProvider).watchOwnedWorlds(user.uid);
 });
 
-/// One world by id.
+/// World ids the signed-in user joined as a player.
+final joinedWorldIdsProvider = StreamProvider<List<String>>((ref) {
+  final user = ref.watch(authStateChangesProvider).valueOrNull;
+  if (user == null) return Stream.value(<String>[]);
+  return ref.watch(worldRepositoryProvider).watchJoinedWorldIds(user.uid);
+});
+
+/// All worlds visible to the signed-in user — owned + joined (deduped),
+/// owned first. Loading until both source streams have emitted at least
+/// once. Each joined world stays live via the per-id [worldProvider].
+final myWorldsProvider = Provider<AsyncValue<List<World>>>((ref) {
+  final ownedAsync = ref.watch(ownedWorldsProvider);
+  final joinedIdsAsync = ref.watch(joinedWorldIdsProvider);
+
+  if (ownedAsync.isLoading || joinedIdsAsync.isLoading) {
+    return const AsyncValue.loading();
+  }
+  if (ownedAsync.hasError) {
+    return AsyncValue.error(ownedAsync.error!, ownedAsync.stackTrace!);
+  }
+  if (joinedIdsAsync.hasError) {
+    return AsyncValue.error(
+        joinedIdsAsync.error!, joinedIdsAsync.stackTrace!);
+  }
+
+  final owned = ownedAsync.requireValue;
+  final ownedIds = owned.map((w) => w.id).toSet();
+  final joinedIds = joinedIdsAsync.requireValue
+      .where((id) => !ownedIds.contains(id))
+      .toList();
+
+  final joined = <World>[];
+  for (final id in joinedIds) {
+    final w = ref.watch(worldProvider(id)).valueOrNull;
+    if (w != null) joined.add(w);
+  }
+
+  return AsyncValue.data([...owned, ...joined]);
+});
+
+/// One world by id, live.
 final worldProvider = StreamProvider.family<World?, String>((ref, id) {
   return ref.watch(worldRepositoryProvider).watchWorld(id);
 });

--- a/apps/dnd_calendar/lib/world_repository.dart
+++ b/apps/dnd_calendar/lib/world_repository.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'models/member.dart';
 import 'models/world.dart';
 
 class WorldRepository {
@@ -12,16 +13,66 @@ class WorldRepository {
   CollectionReference<Map<String, dynamic>> get _worlds =>
       _db.collection('worlds');
 
+  CollectionReference<Map<String, dynamic>> get _joinCodes =>
+      _db.collection('joinCodes');
+
   /// Worlds owned by [uid].
-  ///
-  /// Member-of-but-not-owner worlds will land in S4 once the `members`
-  /// subcollection exists.
-  Stream<List<World>> watchWorldsForUser(String uid) {
+  Stream<List<World>> watchOwnedWorlds(String uid) {
     return _worlds
         .where('ownerUid', isEqualTo: uid)
         .orderBy('createdAt', descending: true)
         .snapshots()
         .map((snap) => snap.docs.map(World.fromFirestore).toList());
+  }
+
+  /// World ids that [uid] joined as a player. Uses a collectionGroup query
+  /// over every `members` subcollection in the database, filtered by `uid`
+  /// (which we mirror onto each member doc for query support).
+  Stream<List<String>> watchJoinedWorldIds(String uid) {
+    return _db
+        .collectionGroup('members')
+        .where('uid', isEqualTo: uid)
+        .snapshots()
+        .map((snap) {
+      final ids = <String>[];
+      for (final d in snap.docs) {
+        // Path: worlds/{worldId}/members/{uid}
+        final parts = d.reference.path.split('/');
+        final worldsIdx = parts.indexOf('worlds');
+        if (worldsIdx >= 0 && worldsIdx + 1 < parts.length) {
+          ids.add(parts[worldsIdx + 1]);
+        }
+      }
+      return ids;
+    });
+  }
+
+  /// Resolve a join code to its world id (or null). Reads from the
+  /// `joinCodes` side-collection so the lookup doesn't require read access
+  /// on the world doc itself.
+  Future<String?> resolveJoinCode(String code) async {
+    final doc = await _joinCodes.doc(code.toUpperCase().trim()).get();
+    if (!doc.exists) return null;
+    return doc.data()?['worldId'] as String?;
+  }
+
+  Future<World?> getWorld(String worldId) async {
+    final doc = await _worlds.doc(worldId).get();
+    return doc.exists ? World.fromFirestore(doc) : null;
+  }
+
+  /// Self-join: writes `worlds/{worldId}/members/{uid}` with role=player.
+  /// Idempotent (re-joining is a no-op).
+  Future<void> joinWorld({required String worldId, required String uid}) async {
+    await _worlds
+        .doc(worldId)
+        .collection('members')
+        .doc(uid)
+        .set({
+      'uid': uid,
+      'role': MemberRole.player.name,
+      'joinedAt': FieldValue.serverTimestamp(),
+    }, SetOptions(merge: true));
   }
 
   Stream<World?> watchWorld(String worldId) {
@@ -31,22 +82,42 @@ class WorldRepository {
   }
 
   /// Create a new world owned by [uid] with the supplied name and a default
-  /// calendar config. Returns the new world's id.
+  /// calendar config. Writes the world doc and a sibling `joinCodes/{code}`
+  /// pointer in a single batch so the join-by-code flow can resolve a code
+  /// without needing read access on every world doc.
+  ///
+  /// Retries on join-code collision (up to 5 attempts).
   Future<String> createWorld({required String uid, required String name}) async {
-    final doc = _worlds.doc();
-    final world = World(
-      id: doc.id,
-      ownerUid: uid,
-      name: name.trim(),
-      joinCode: _generateJoinCode(),
-      calendar: defaultCalendar(),
-      createdAt: null, // server timestamp written below
-    );
-    await doc.set({
-      ...world.toFirestore(),
-      'createdAt': FieldValue.serverTimestamp(),
-    });
-    return doc.id;
+    var attempts = 0;
+    while (true) {
+      attempts += 1;
+      final doc = _worlds.doc();
+      final code = _generateJoinCode();
+      final world = World(
+        id: doc.id,
+        ownerUid: uid,
+        name: name.trim(),
+        joinCode: code,
+        calendar: defaultCalendar(),
+        createdAt: null,
+      );
+      try {
+        final batch = _db.batch();
+        batch.set(doc, {
+          ...world.toFirestore(),
+          'createdAt': FieldValue.serverTimestamp(),
+        });
+        batch.set(_joinCodes.doc(code), {
+          'worldId': doc.id,
+          'ownerUid': uid,
+        });
+        await batch.commit();
+        return doc.id;
+      } on FirebaseException catch (e) {
+        // Collision on joinCodes (already-exists) → retry with a fresh code.
+        if (attempts >= 5 || e.code != 'already-exists') rethrow;
+      }
+    }
   }
 
   /// Replace the calendar config of one world. Owner-only — Firestore rules

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,14 @@ rules_version = '2';
 
 // Firestore security rules for dnd-calendar.
 //
-// MVP shape — kept loose where the membership system isn't built yet (S1).
-// S4 tightens the per-world read gate to "must be member or owner".
-// S3/S5/S6 add per-subcollection rules.
+// Top-level structure:
+//   worlds/{worldId}                 — world doc
+//   worlds/{w}/members/{uid}         — membership
+//   worlds/{w}/events/{eventId}
+//   worlds/{w}/events/{e}/registrations/{uid}
+//   worlds/{w}/characters/{charId}
+//   joinCodes/{code}                 — pointer doc { worldId, ownerUid }
+//                                      so non-members can resolve codes
 service cloud.firestore {
   match /databases/{database}/documents {
 
@@ -18,44 +23,69 @@ service cloud.firestore {
           && get(/databases/$(database)/documents/worlds/$(worldId)).data.ownerUid == request.auth.uid;
     }
 
-    match /worlds/{worldId} {
-      // Read: any authed user (S4 will narrow to members + owner).
-      allow read: if signedIn();
+    function isMember(worldId) {
+      return signedIn()
+          && exists(/databases/$(database)/documents/worlds/$(worldId)/members/$(request.auth.uid));
+    }
 
-      // Create: only as your own world; ownerUid must match auth.uid.
+    function canSeeWorld(worldId) {
+      return isOwner(worldId) || isMember(worldId);
+    }
+
+    match /worlds/{worldId} {
+      allow read: if canSeeWorld(worldId);
       allow create: if signedIn()
         && request.resource.data.ownerUid == request.auth.uid;
-
-      // Update / delete: only owner; ownerUid is immutable.
       allow update: if isOwner(worldId)
         && request.resource.data.ownerUid == resource.data.ownerUid;
       allow delete: if isOwner(worldId);
 
-      // Events — read for any signed-in (S4 narrows to members + owner),
-      // write only by world owner. createdByUid must match auth.uid on
-      // create and stay immutable on update.
+      // Members — self-join, owner can remove (post-MVP UI).
+      match /members/{memberUid} {
+        allow read: if canSeeWorld(worldId);
+        allow create: if signedIn()
+          && memberUid == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow update: if signedIn() && memberUid == request.auth.uid;
+        allow delete: if isOwner(worldId)
+          || (signedIn() && memberUid == request.auth.uid);
+      }
+
+      // Events — read: owner or member; write: owner only.
       match /events/{eventId} {
-        allow read: if signedIn();
+        allow read: if canSeeWorld(worldId);
         allow create: if isOwner(worldId)
           && request.resource.data.createdByUid == request.auth.uid;
         allow update: if isOwner(worldId)
           && request.resource.data.createdByUid == resource.data.createdByUid;
         allow delete: if isOwner(worldId);
 
-        // Registrations — placeholder until S6.
+        // Registrations — placeholder until S6 lands character logic.
         match /registrations/{regUid} {
-          allow read, write: if signedIn();
+          allow read: if canSeeWorld(worldId);
+          allow write: if signedIn() && regUid == request.auth.uid;
         }
       }
 
-      // Other subcollections (members, characters) — placeholders until
-      // S4/S5 land their real rules.
-      match /members/{memberUid} {
-        allow read, write: if signedIn();
-      }
+      // Characters — placeholder until S5.
       match /characters/{charId} {
-        allow read, write: if signedIn();
+        allow read: if canSeeWorld(worldId);
+        allow write: if canSeeWorld(worldId);
       }
+    }
+
+    // Public-ish join-code lookup. Any signed-in user may read so the
+    // join flow can resolve a code → worldId without first being a member.
+    // Writes are restricted to the world's owner.
+    match /joinCodes/{code} {
+      allow read: if signedIn();
+      allow create: if signedIn()
+        && request.resource.data.ownerUid == request.auth.uid;
+      allow update: if signedIn()
+        && resource.data.ownerUid == request.auth.uid
+        && request.resource.data.ownerUid == request.auth.uid;
+      allow delete: if signedIn()
+        && resource.data.ownerUid == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Player flow: tap login icon in app bar → enter 6-char code → land on the world's detail screen as a member
- World list now splits into "You DM" and "You joined" sections
- Owner is implicit (derived from `worlds/{w}.ownerUid`); members live in `worlds/{w}/members/{uid}`

## Architecture choice — `joinCodes` side-collection

Tightened rules require `owner OR member` to read a world. That conflicts with the join-by-code flow which needs to resolve a code → worldId before becoming a member. Cloud Functions are out of scope for MVP.

Solution: a `joinCodes/{code}` pointer collection (`{ worldId, ownerUid }`) writable only by the world's owner, readable by any signed-in user. `createWorld` writes both docs in a single batch. The join screen reads `joinCodes/{code}.worldId`, then writes `members/{uid}` — at which point the world doc becomes readable.

## Files of interest

- `models/member.dart` — Member freezed
- `world_repository.dart` — `createWorld` (batched, with collision retry), `resolveJoinCode`, `joinWorld`, `watchJoinedWorldIds` (collectionGroup)
- `world_providers.dart` — `ownedWorldsProvider`, `joinedWorldIdsProvider`, `myWorldsProvider` (combiner)
- `join_world_screen.dart`
- `firestore.rules` — `canSeeWorld` helper, narrowed reads, `joinCodes` rules

## Manual setup needed

After pulling:
```
cd apps/dnd_calendar
flutter pub get
dart run build_runner build --delete-conflicting-outputs
```

Then deploy the new rules:
```
firebase deploy --only firestore:rules
```

The collectionGroup query needs a composite index on `members` collectionGroup with `uid` field. Firestore will surface a console link the first time it runs — open it and click "Create".

## Test plan

- [x] `dart analyze` clean
- [x] `dart run build_runner build` succeeds
- [ ] Manual on emulator: A creates world → joinCode visible → A signs out → B signs in → B taps Join → enters code → lands on detail → world appears in B's "You joined" list
- [ ] B can see calendar + events; cannot Edit calendar or create events
- [ ] C without code cannot read the world doc directly (Firestore should reject)

Closes #6