### PR TITLE
S5: characters per (user, world)

### DIFF
--- a/apps/dnd_calendar/lib/character_providers.dart
+++ b/apps/dnd_calendar/lib/character_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'character_repository.dart';
+import 'models/character.dart';
+import 'world_providers.dart';
+
+final characterRepositoryProvider = Provider<CharacterRepository>(
+  (ref) => CharacterRepository(ref.watch(firestoreProvider)),
+);
+
+final charactersProvider =
+    StreamProvider.family<List<Character>, String>((ref, worldId) {
+  return ref.watch(characterRepositoryProvider).watchCharacters(worldId);
+});

--- a/apps/dnd_calendar/lib/character_repository.dart
+++ b/apps/dnd_calendar/lib/character_repository.dart
@@ -1,0 +1,41 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'models/character.dart';
+
+class CharacterRepository {
+  CharacterRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  CollectionReference<Map<String, dynamic>> _characters(String worldId) =>
+      _db.collection('worlds').doc(worldId).collection('characters');
+
+  Stream<List<Character>> watchCharacters(String worldId) {
+    return _characters(worldId)
+        .orderBy('name')
+        .snapshots()
+        .map((snap) => snap.docs
+            .map((d) => Character.fromFirestore(d, worldId))
+            .toList());
+  }
+
+  Stream<Character?> watchCharacter(String worldId, String characterId) {
+    return _characters(worldId).doc(characterId).snapshots().map(
+          (d) => d.exists ? Character.fromFirestore(d, worldId) : null,
+        );
+  }
+
+  Future<String> createCharacter(Character c) async {
+    final doc = _characters(c.worldId).doc();
+    await doc.set(c.toFirestore());
+    return doc.id;
+  }
+
+  Future<void> updateCharacter(Character c) async {
+    await _characters(c.worldId).doc(c.id).update(c.toFirestore());
+  }
+
+  Future<void> deleteCharacter(String worldId, String characterId) async {
+    await _characters(worldId).doc(characterId).delete();
+  }
+}

--- a/apps/dnd_calendar/lib/characters_section.dart
+++ b/apps/dnd_calendar/lib/characters_section.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth_providers.dart';
+import 'character_providers.dart';
+import 'models/character.dart';
+
+class CharactersSection extends ConsumerWidget {
+  const CharactersSection({super.key, required this.worldId});
+
+  final String worldId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final me = ref.watch(authStateChangesProvider).valueOrNull;
+    final charsAsync = ref.watch(charactersProvider(worldId));
+
+    return Scaffold(
+      body: charsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (chars) {
+          if (chars.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'No characters yet. Tap + to add yours.',
+                  style: TextStyle(fontSize: 14),
+                ),
+              ),
+            );
+          }
+          // Group: yours first, then everyone else's.
+          final mine = <Character>[];
+          final others = <Character>[];
+          for (final c in chars) {
+            (c.uid == me?.uid ? mine : others).add(c);
+          }
+          return ListView(
+            padding: const EdgeInsets.only(bottom: 96),
+            children: [
+              if (mine.isNotEmpty) ...[
+                const _Header('Yours'),
+                for (final c in mine)
+                  _CharacterTile(character: c, mine: true),
+              ],
+              if (others.isNotEmpty) ...[
+                const _Header('Others'),
+                for (final c in others)
+                  _CharacterTile(character: c, mine: false),
+              ],
+            ],
+          );
+        },
+      ),
+      floatingActionButton: me == null
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: () => _openEdit(context),
+              icon: const Icon(Icons.add),
+              label: const Text('New character'),
+            ),
+    );
+  }
+
+  void _openEdit(BuildContext context, [Character? existing]) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) =>
+            CharacterEditScreen(worldId: worldId, existing: existing),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header(this.text);
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        text.toUpperCase(),
+        style: TextStyle(
+          fontSize: 12,
+          letterSpacing: 1,
+          color: Theme.of(context).hintColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _CharacterTile extends ConsumerWidget {
+  const _CharacterTile({required this.character, required this.mine});
+
+  final Character character;
+  final bool mine;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final subtitle = [
+      if (character.characterClass.isNotEmpty) character.characterClass,
+      'Level ${character.level}',
+      if (!mine && character.ownerDisplayName.isNotEmpty)
+        'by ${character.ownerDisplayName}',
+    ].join(' · ');
+
+    return ListTile(
+      leading: const Icon(Icons.person),
+      title: Text(character.name),
+      subtitle: Text(subtitle),
+      trailing: mine
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => CharacterEditScreen(
+                        worldId: character.worldId,
+                        existing: character,
+                      ),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () => _confirmDelete(context, ref),
+                ),
+              ],
+            )
+          : null,
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text('Delete ${character.name}?'),
+        content: const Text('Existing registrations stay; new sign-ups are blocked.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Keep'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await ref
+        .read(characterRepositoryProvider)
+        .deleteCharacter(character.worldId, character.id);
+  }
+}
+
+// ─── Edit screen ────────────────────────────────────────────────────────────
+
+class CharacterEditScreen extends ConsumerStatefulWidget {
+  const CharacterEditScreen({
+    super.key,
+    required this.worldId,
+    this.existing,
+  });
+
+  final String worldId;
+  final Character? existing;
+
+  @override
+  ConsumerState<CharacterEditScreen> createState() =>
+      _CharacterEditScreenState();
+}
+
+class _CharacterEditScreenState extends ConsumerState<CharacterEditScreen> {
+  final _nameCtl = TextEditingController();
+  final _classCtl = TextEditingController();
+  final _levelCtl = TextEditingController(text: '1');
+  bool _busy = false;
+  String? _error;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final c = widget.existing;
+    if (c != null) {
+      _nameCtl.text = c.name;
+      _classCtl.text = c.characterClass;
+      _levelCtl.text = c.level.toString();
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameCtl.dispose();
+    _classCtl.dispose();
+    _levelCtl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final name = _nameCtl.text.trim();
+    if (name.isEmpty) {
+      setState(() => _error = 'Name is required');
+      return;
+    }
+    final level = int.tryParse(_levelCtl.text.trim());
+    if (level == null || level < 1) {
+      setState(() => _error = 'Level must be a positive number');
+      return;
+    }
+    final user = ref.read(authStateChangesProvider).valueOrNull;
+    if (user == null) {
+      setState(() => _error = 'Not signed in');
+      return;
+    }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final repo = ref.read(characterRepositoryProvider);
+      final character = (widget.existing ??
+              Character(
+                id: '',
+                worldId: widget.worldId,
+                uid: user.uid,
+                ownerDisplayName: user.displayName ?? user.email ?? '',
+                name: name,
+              ))
+          .copyWith(
+        name: name,
+        characterClass: _classCtl.text.trim(),
+        level: level,
+        ownerDisplayName: user.displayName ?? user.email ?? '',
+      );
+      if (_isEdit) {
+        await repo.updateCharacter(character);
+      } else {
+        await repo.createCharacter(character);
+      }
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEdit ? 'Edit character' : 'New character'),
+        actions: [
+          if (_busy)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+            )
+          else
+            TextButton(
+              onPressed: _save,
+              child: const Text('Save', style: TextStyle(color: Colors.white)),
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+          TextField(
+            controller: _nameCtl,
+            decoration: const InputDecoration(labelText: 'Name'),
+            textCapitalization: TextCapitalization.words,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _classCtl,
+            decoration: const InputDecoration(
+              labelText: 'Class',
+              hintText: 'e.g. Wizard, Rogue, Fighter',
+            ),
+            textCapitalization: TextCapitalization.words,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _levelCtl,
+            decoration: const InputDecoration(labelText: 'Level'),
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/models/character.dart
+++ b/apps/dnd_calendar/lib/models/character.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'character.freezed.dart';
+part 'character.g.dart';
+
+/// Thin character card scoped to one (user, world). Full character sheet
+/// lives outside the app — this is just enough to identify a character at
+/// quest sign-up.
+///
+/// `ownerDisplayName` is denormalized from Firebase Auth at write time so
+/// the DM and other players can see whose character is whose without an
+/// extra users-collection lookup.
+@freezed
+class Character with _$Character {
+  const Character._();
+  const factory Character({
+    required String id,
+    required String worldId,
+    required String uid,
+    @Default('') String ownerDisplayName,
+    required String name,
+    @Default('') String characterClass,
+    @Default(1) int level,
+  }) = _Character;
+  factory Character.fromJson(Map<String, dynamic> json) =>
+      _$CharacterFromJson(json);
+
+  factory Character.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+    String worldId,
+  ) {
+    final data = doc.data()!;
+    return Character.fromJson({...data, 'id': doc.id, 'worldId': worldId});
+  }
+
+  Map<String, dynamic> toFirestore() {
+    final j = toJson();
+    j.remove('id');
+    j.remove('worldId');
+    return j;
+  }
+}

--- a/apps/dnd_calendar/lib/world_detail_screen.dart
+++ b/apps/dnd_calendar/lib/world_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth_providers.dart';
 import 'calendar_config_edit_screen.dart';
+import 'characters_section.dart';
 import 'events_section.dart';
 import 'models/world.dart';
 import 'world_providers.dart';
@@ -34,7 +35,7 @@ class WorldDetailScreen extends ConsumerWidget {
         }
         final isOwner = me?.uid == w.ownerUid;
         return DefaultTabController(
-          length: 2,
+          length: 3,
           child: Scaffold(
             appBar: AppBar(
               title: Text(w.name),
@@ -42,6 +43,7 @@ class WorldDetailScreen extends ConsumerWidget {
                 tabs: [
                   Tab(icon: Icon(Icons.castle), text: 'Overview'),
                   Tab(icon: Icon(Icons.event), text: 'Events'),
+                  Tab(icon: Icon(Icons.people), text: 'Characters'),
                 ],
               ),
             ),
@@ -49,6 +51,7 @@ class WorldDetailScreen extends ConsumerWidget {
               children: [
                 _OverviewTab(world: w, isOwner: isOwner),
                 EventsSection(worldId: w.id, calendar: w.calendar),
+                CharactersSection(worldId: w.id),
               ],
             ),
           ),

--- a/firestore.rules
+++ b/firestore.rules
@@ -67,10 +67,17 @@ service cloud.firestore {
         }
       }
 
-      // Characters — placeholder until S5.
+      // Characters — read for owner/members; write only by the character's
+      // own owner (uid field in the doc must match auth.uid). Owner of
+      // the world cannot edit other people's characters.
       match /characters/{charId} {
         allow read: if canSeeWorld(worldId);
-        allow write: if canSeeWorld(worldId);
+        allow create: if canSeeWorld(worldId)
+          && request.resource.data.uid == request.auth.uid;
+        allow update: if signedIn()
+          && resource.data.uid == request.auth.uid
+          && request.resource.data.uid == request.auth.uid;
+        allow delete: if signedIn() && resource.data.uid == request.auth.uid;
       }
     }
 


### PR DESCRIPTION
## Summary

Per-world character cards. Each player can own multiple characters scoped to a single world. Thin model — just enough to identify a character at sign-up time. Full sheets stay outside the app.

## What it adds

- `models/character.dart` — `{ id, worldId, uid, ownerDisplayName, name, characterClass, level }`. `ownerDisplayName` denormalized from Firebase Auth at write time
- `character_repository.dart`, `character_providers.dart`
- `characters_section.dart` — third tab on world detail
  - "Yours" section (with edit/delete) + "Others" section (read-only)
  - FAB → CharacterEditScreen
- Firestore rules: `worlds/{w}/characters/{c}` create/update/delete restricted to `request.resource.data.uid == auth.uid`. Even the world owner can't touch other players' characters.

## Test plan

- [x] `dart analyze` clean
- [x] `dart run build_runner build` succeeds
- [ ] Manual: create 2 characters in a joined world → edit one → delete one → second player sees them under "Others" with the correct owner name
- [ ] Verify Firestore rejects: player A trying to edit player B's character

Closes #7