### PR TITLE
S6: quest registration with character overlap check

### DIFF
--- a/apps/dnd_calendar/lib/event_detail_screen.dart
+++ b/apps/dnd_calendar/lib/event_detail_screen.dart
@@ -3,10 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'auth_providers.dart';
+import 'character_providers.dart';
 import 'event_edit_screen.dart';
 import 'event_providers.dart';
+import 'models/character.dart';
 import 'models/event.dart';
+import 'models/registration.dart';
 import 'models/world.dart';
+import 'registration_providers.dart';
+import 'registration_repository.dart';
 import 'world_providers.dart';
 
 class EventDetailScreen extends ConsumerWidget {
@@ -70,6 +75,23 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final c = world.toEngine();
     final start = engine.formatDate(event.startDate.toEngine(), c);
+    final regsAsync = ref.watch(
+      registrationsProvider((worldId: event.worldId, eventId: event.id)),
+    );
+    final me = ref.watch(authStateChangesProvider).valueOrNull;
+    final regCount = regsAsync.valueOrNull?.length ?? 0;
+    final myReg = regsAsync.valueOrNull?.firstWhere(
+      (r) => r.uid == me?.uid,
+      orElse: () => Registration(
+        uid: '',
+        worldId: '',
+        eventId: '',
+        characterId: '',
+        eventStartDate: event.startDate,
+      ),
+    );
+    final iAmRegistered = myReg != null && myReg.uid.isNotEmpty;
+
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -95,7 +117,9 @@ class _Body extends ConsumerWidget {
         _kv(
           context,
           'Capacity',
-          event.capacity == null ? 'unlimited' : '0 / ${event.capacity}',
+          event.capacity == null
+              ? '$regCount signed up · unlimited'
+              : '$regCount / ${event.capacity}',
         ),
         const SizedBox(height: 16),
         if (event.description.isNotEmpty)
@@ -128,13 +152,168 @@ class _Body extends ConsumerWidget {
             ],
           ),
         ],
-        const SizedBox(height: 24),
-        const Text(
-          'Player registration lands in S6.',
-          style: TextStyle(fontSize: 12),
+        const SizedBox(height: 16),
+        const Divider(),
+        // Sign-up actions
+        if (event.status == EventStatus.cancelled)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: Text(
+              'This event was cancelled — sign-ups are closed.',
+              style: TextStyle(fontSize: 13),
+            ),
+          )
+        else if (me != null) ...[
+          if (iAmRegistered)
+            FilledButton.tonalIcon(
+              icon: const Icon(Icons.logout),
+              label: Text(
+                'Unregister ${myReg.characterName.isEmpty ? '' : '(${myReg.characterName})'}',
+              ),
+              onPressed: () => _unregister(context, ref, me.uid),
+            )
+          else
+            FilledButton.icon(
+              icon: const Icon(Icons.how_to_reg),
+              label: const Text('Sign up'),
+              onPressed: () => _openSignUp(context, ref, me.uid, c),
+            ),
+        ],
+        const SizedBox(height: 16),
+        Text('Registrations', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 4),
+        regsAsync.when(
+          loading: () => const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Text('Error: $e'),
+          data: (regs) {
+            if (regs.isEmpty) {
+              return const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  'No one has signed up yet.',
+                  style: TextStyle(fontSize: 13),
+                ),
+              );
+            }
+            return Column(
+              children: [
+                for (final r in regs)
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.person),
+                    title: Text(
+                      r.characterName.isEmpty
+                          ? '(unnamed character)'
+                          : r.characterName,
+                    ),
+                    subtitle: Text(
+                      r.ownerDisplayName.isEmpty
+                          ? r.uid
+                          : 'by ${r.ownerDisplayName}',
+                    ),
+                  ),
+              ],
+            );
+          },
         ),
       ],
     );
+  }
+
+  Future<void> _openSignUp(
+    BuildContext context,
+    WidgetRef ref,
+    String uid,
+    engine.CalendarConfig calendar,
+  ) async {
+    final charsAsync = ref.read(charactersProvider(event.worldId));
+    final chars = charsAsync.valueOrNull ?? [];
+    final mine = chars.where((c) => c.uid == uid).toList();
+    if (mine.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Create a character first (Characters tab).'),
+        ),
+      );
+      return;
+    }
+    final picked = await showModalBottomSheet<Character>(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(12),
+              child:
+                  Text('Pick a character', style: TextStyle(fontSize: 16)),
+            ),
+            for (final c in mine)
+              ListTile(
+                leading: const Icon(Icons.person),
+                title: Text(c.name),
+                subtitle: Text(
+                  '${c.characterClass.isEmpty ? '—' : c.characterClass} · '
+                  'Level ${c.level}',
+                ),
+                onTap: () => Navigator.of(context).pop(c),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (picked == null || !context.mounted) return;
+    try {
+      await ref.read(registrationRepositoryProvider).register(
+            worldId: event.worldId,
+            eventId: event.id,
+            uid: uid,
+            characterId: picked.id,
+            characterName: picked.name,
+            ownerDisplayName: picked.ownerDisplayName,
+            eventStartDate: event.startDate,
+            eventEndDate: event.endDate,
+            calendar: calendar,
+          );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${picked.name} signed up.')),
+        );
+      }
+    } on OverlapException catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '${picked.name} is already signed up for "${e.conflict.characterName}\'s" '
+              'event on overlapping dates.',
+            ),
+            duration: const Duration(seconds: 5),
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Sign-up failed: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _unregister(
+    BuildContext context,
+    WidgetRef ref,
+    String uid,
+  ) async {
+    await ref.read(registrationRepositoryProvider).unregister(
+          worldId: event.worldId,
+          eventId: event.id,
+          uid: uid,
+        );
   }
 
   Future<void> _confirmCancel(BuildContext context, WidgetRef ref) async {

--- a/apps/dnd_calendar/lib/models/registration.dart
+++ b/apps/dnd_calendar/lib/models/registration.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'world.dart';
+
+part 'registration.freezed.dart';
+part 'registration.g.dart';
+
+/// One character signed up for one event. Doc id is the player's uid so
+/// each user has at most one registration per event.
+///
+/// Several fields (`characterName`, `ownerDisplayName`, `eventStartDate`,
+/// `eventEndDate`) are denormalized so:
+///  - the registrations list on event detail renders without extra lookups
+///  - overlap checking can be done with a single collectionGroup query
+///    over /registrations filtered by characterId
+@freezed
+class Registration with _$Registration {
+  const Registration._();
+  const factory Registration({
+    required String uid,
+    required String worldId,
+    required String eventId,
+    required String characterId,
+    @Default('') String characterName,
+    @Default('') String ownerDisplayName,
+    required WorldDateData eventStartDate,
+    WorldDateData? eventEndDate,
+    @TimestampConverter() DateTime? registeredAt,
+  }) = _Registration;
+  factory Registration.fromJson(Map<String, dynamic> json) =>
+      _$RegistrationFromJson(json);
+
+  factory Registration.fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+    String worldId,
+    String eventId,
+  ) {
+    final data = doc.data()!;
+    return Registration.fromJson(
+      {...data, 'uid': doc.id, 'worldId': worldId, 'eventId': eventId},
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    final j = toJson();
+    j.remove('uid');
+    j.remove('worldId');
+    j.remove('eventId');
+    return j;
+  }
+}

--- a/apps/dnd_calendar/lib/registration_providers.dart
+++ b/apps/dnd_calendar/lib/registration_providers.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models/registration.dart';
+import 'registration_repository.dart';
+import 'world_providers.dart';
+
+final registrationRepositoryProvider = Provider<RegistrationRepository>(
+  (ref) => RegistrationRepository(ref.watch(firestoreProvider)),
+);
+
+final registrationsProvider = StreamProvider.family<List<Registration>,
+    ({String worldId, String eventId})>(
+  (ref, k) => ref
+      .watch(registrationRepositoryProvider)
+      .watchRegistrations(k.worldId, k.eventId),
+);

--- a/apps/dnd_calendar/lib/registration_repository.dart
+++ b/apps/dnd_calendar/lib/registration_repository.dart
@@ -1,0 +1,123 @@
+import 'package:calendar_engine/calendar_engine.dart' as engine;
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'models/registration.dart';
+import 'models/world.dart';
+
+/// Thrown when a registration would overlap an existing one for the same
+/// character. Carries the conflicting registration for UI display.
+class OverlapException implements Exception {
+  OverlapException(this.conflict);
+  final Registration conflict;
+  @override
+  String toString() =>
+      'Character already registered for an event on overlapping dates.';
+}
+
+class RegistrationRepository {
+  RegistrationRepository(this._db);
+
+  final FirebaseFirestore _db;
+
+  CollectionReference<Map<String, dynamic>> _regs(
+    String worldId,
+    String eventId,
+  ) =>
+      _db
+          .collection('worlds')
+          .doc(worldId)
+          .collection('events')
+          .doc(eventId)
+          .collection('registrations');
+
+  /// All registrations on one event, sorted by registeredAt ascending.
+  Stream<List<Registration>> watchRegistrations(
+    String worldId,
+    String eventId,
+  ) {
+    return _regs(worldId, eventId)
+        .orderBy('registeredAt')
+        .snapshots()
+        .map((snap) => snap.docs
+            .map((d) => Registration.fromFirestore(d, worldId, eventId))
+            .toList());
+  }
+
+  /// Sign a character up for an event. Performs an overlap check against
+  /// every existing registration of that character in this world; throws
+  /// [OverlapException] on conflict.
+  ///
+  /// Capacity is **not** enforced here per CONTEXT.md (out of scope MVP).
+  Future<void> register({
+    required String worldId,
+    required String eventId,
+    required String uid,
+    required String characterId,
+    required String characterName,
+    required String ownerDisplayName,
+    required WorldDateData eventStartDate,
+    WorldDateData? eventEndDate,
+    required engine.CalendarConfig calendar,
+  }) async {
+    // Overlap query: all registrations across this world for this character.
+    // collectionGroup matches every `registrations` subcollection in the DB;
+    // we filter to this world by inspecting the doc path below.
+    final snap = await _db
+        .collectionGroup('registrations')
+        .where('characterId', isEqualTo: characterId)
+        .get();
+
+    final newStart = eventStartDate.toEngine();
+    final newEnd = (eventEndDate ?? eventStartDate).toEngine();
+
+    for (final doc in snap.docs) {
+      // Skip docs from other worlds.
+      final path = doc.reference.path.split('/');
+      final wIdx = path.indexOf('worlds');
+      if (wIdx < 0 || wIdx + 1 >= path.length) continue;
+      if (path[wIdx + 1] != worldId) continue;
+
+      // Skip the same-event re-register case.
+      final eIdx = path.indexOf('events');
+      if (eIdx >= 0 && eIdx + 1 < path.length && path[eIdx + 1] == eventId) {
+        continue;
+      }
+
+      final reg = Registration.fromFirestore(
+        doc,
+        path[wIdx + 1],
+        path[eIdx + 1],
+      );
+      final existingStart = reg.eventStartDate.toEngine();
+      final existingEnd = (reg.eventEndDate ?? reg.eventStartDate).toEngine();
+
+      // Inclusive overlap: ranges share at least one day iff
+      //   newStart <= existingEnd && existingStart <= newEnd
+      final newStartDays = engine.daysSinceEpoch(newStart, calendar);
+      final newEndDays = engine.daysSinceEpoch(newEnd, calendar);
+      final existingStartDays = engine.daysSinceEpoch(existingStart, calendar);
+      final existingEndDays = engine.daysSinceEpoch(existingEnd, calendar);
+
+      if (newStartDays <= existingEndDays && existingStartDays <= newEndDays) {
+        throw OverlapException(reg);
+      }
+    }
+
+    await _regs(worldId, eventId).doc(uid).set({
+      'characterId': characterId,
+      'characterName': characterName,
+      'ownerDisplayName': ownerDisplayName,
+      'eventStartDate': eventStartDate.toJson(),
+      'eventEndDate': eventEndDate?.toJson(),
+      'registeredAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> unregister({
+    required String worldId,
+    required String eventId,
+    required String uid,
+  }) async {
+    await _regs(worldId, eventId).doc(uid).delete();
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -60,10 +60,17 @@ service cloud.firestore {
           && request.resource.data.createdByUid == resource.data.createdByUid;
         allow delete: if isOwner(worldId);
 
-        // Registrations — placeholder until S6 lands character logic.
+        // Registrations — read for owner/members. Write only when the
+        // path uid matches auth.uid AND the requester is owner-or-member.
+        // Owner can also delete (e.g. removing a no-show).
         match /registrations/{regUid} {
           allow read: if canSeeWorld(worldId);
-          allow write: if signedIn() && regUid == request.auth.uid;
+          allow create: if canSeeWorld(worldId)
+            && regUid == request.auth.uid;
+          allow update: if canSeeWorld(worldId)
+            && regUid == request.auth.uid;
+          allow delete: if signedIn()
+            && (regUid == request.auth.uid || isOwner(worldId));
         }
       }
 


### PR DESCRIPTION
## Summary

Players sign up a character for an event from the event detail screen. The hard invariant from CONTEXT.md — *a character cannot hold two registrations whose date ranges overlap* — is enforced client-side before each write.

## Architecture notes

- `Registration` doc id = player's `uid` so each user has at most one registration per event (re-signing replaces).
- `characterName`, `ownerDisplayName`, `eventStartDate`, `eventEndDate` are denormalized:
  - registrations list renders with zero extra reads
  - overlap check = single `collectionGroup('registrations').where('characterId', ==, X)` query, then in-memory comparison via `engine.daysSinceEpoch` and `engine.daysBetween`
- Same-event re-register is skipped from the overlap check (you can switch which character represents you on an event).

## UI

- Event detail capacity line now shows "3 / 6" (or "3 signed up · unlimited")
- Sign-up flow: button → bottom-sheet character picker (only this user's characters in this world) → confirm
- Unregister button visible only on your own registration
- Registrations list sorted by `registeredAt`
- Friendly snackbar "Create a character first (Characters tab)" when you have none
- `OverlapException` surfaces a clear snackbar naming the conflicting event

## Firestore rules

`worlds/{w}/events/{e}/registrations/{uid}`:
- read: owner or member
- create / update: path uid must match auth.uid AND requester is owner-or-member
- delete: self OR world owner

## Test plan

- [x] `dart analyze` clean
- [x] `dart run build_runner build` succeeds
- [ ] Manual: sign up character A for event X (Day 5) → try to sign up A for event Y (Day 5) → blocked with snackbar → switch picker to character B for Y → succeeds
- [ ] Same-character re-register on same event swaps the row
- [ ] Unregister removes the row
- [ ] Verify Firestore index prompt for `collectionGroup('registrations') where characterId ==` — accept the console link the first time

Closes #8