### PR TITLE
S7: date advance + moon indicators + multi-day events + polish

### DIFF
--- a/apps/dnd_calendar/lib/event_detail_screen.dart
+++ b/apps/dnd_calendar/lib/event_detail_screen.dart
@@ -10,6 +10,7 @@ import 'models/character.dart';
 import 'models/event.dart';
 import 'models/registration.dart';
 import 'models/world.dart';
+import 'moon_strip.dart';
 import 'registration_providers.dart';
 import 'registration_repository.dart';
 import 'world_providers.dart';
@@ -75,6 +76,11 @@ class _Body extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final c = world.toEngine();
     final start = engine.formatDate(event.startDate.toEngine(), c);
+    final isMultiDay =
+        event.endDate != null && event.endDate != event.startDate;
+    final endStr = isMultiDay
+        ? engine.formatDate(event.endDate!.toEngine(), c)
+        : null;
     final regsAsync = ref.watch(
       registrationsProvider((worldId: event.worldId, eventId: event.id)),
     );
@@ -106,8 +112,11 @@ class _Body extends ConsumerWidget {
             _StatusBadge(status: event.status),
           ],
         ),
+        const SizedBox(height: 8),
+        MoonStrip(calendar: world, date: event.startDate),
         const SizedBox(height: 12),
-        _kv(context, 'When', start),
+        _kv(context, 'Starts', start),
+        if (endStr != null) _kv(context, 'Ends', endStr),
         if (event.registrationDeadline != event.startDate)
           _kv(
             context,

--- a/apps/dnd_calendar/lib/event_edit_screen.dart
+++ b/apps/dnd_calendar/lib/event_edit_screen.dart
@@ -31,6 +31,7 @@ class _EventEditScreenState extends ConsumerState<EventEditScreen> {
   final _descCtl = TextEditingController();
   final _capacityCtl = TextEditingController();
   late WorldDateData _startDate;
+  WorldDateData? _endDate;
   WorldDateData? _deadline;
   bool _busy = false;
   String? _error;
@@ -46,9 +47,11 @@ class _EventEditScreenState extends ConsumerState<EventEditScreen> {
       _descCtl.text = e.description;
       _capacityCtl.text = e.capacity?.toString() ?? '';
       _startDate = e.startDate;
+      _endDate = e.endDate == e.startDate ? null : e.endDate;
       _deadline = e.registrationDeadline == e.startDate ? null : e.registrationDeadline;
     } else {
       _startDate = widget.calendar.currentDate;
+      _endDate = null;
       _deadline = null;
     }
   }
@@ -98,6 +101,7 @@ class _EventEditScreenState extends ConsumerState<EventEditScreen> {
         title: title,
         description: _descCtl.text.trim(),
         startDate: _startDate,
+        endDate: _endDate,
         registrationDeadline: _deadline ?? _startDate,
         capacity: capacity,
       );
@@ -167,7 +171,24 @@ class _EventEditScreenState extends ConsumerState<EventEditScreen> {
             initial: _startDate,
             onChanged: (d) => setState(() => _startDate = d),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 8),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Multi-day event'),
+            value: _endDate != null,
+            onChanged: (v) => setState(() {
+              _endDate = v ? _startDate : null;
+            }),
+          ),
+          if (_endDate != null) ...[
+            WorldDatePicker(
+              label: 'End date',
+              calendar: widget.calendar,
+              initial: _endDate ?? _startDate,
+              onChanged: (d) => setState(() => _endDate = d),
+            ),
+            const SizedBox(height: 16),
+          ],
           WorldDatePicker(
             label: 'Registration deadline (default = start date)',
             calendar: widget.calendar,

--- a/apps/dnd_calendar/lib/events_section.dart
+++ b/apps/dnd_calendar/lib/events_section.dart
@@ -227,6 +227,10 @@ class _EventTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final start = engine.formatDate(event.startDate.toEngine(), calendar);
     final cancelled = event.status == EventStatus.cancelled;
+    final hasEnd = event.endDate != null && event.endDate != event.startDate;
+    final subtitle = hasEnd
+        ? '$start  →  ${engine.formatDate(event.endDate!.toEngine(), calendar)}'
+        : start;
     return ListTile(
       leading: Icon(
         cancelled ? Icons.cancel_outlined : Icons.event,
@@ -239,7 +243,7 @@ class _EventTile extends StatelessWidget {
           color: dim ? Theme.of(context).hintColor : null,
         ),
       ),
-      subtitle: Text(start),
+      subtitle: Text(subtitle),
       onTap: () => Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => EventDetailScreen(
@@ -280,12 +284,27 @@ class _MonthView extends StatelessWidget {
       engine.WorldDate(year: year, monthIndex: monthIndex, day: 1),
       c,
     );
-    // Group events by day-of-month for this (year, monthIndex).
+    // Group events by day-of-month for this (year, monthIndex). Multi-day
+    // events appear on every day in their range that intersects the
+    // currently-viewed month.
     final byDay = <int, List<Event>>{};
+    final monthFirst = engine.daysSinceEpoch(
+      engine.WorldDate(year: year, monthIndex: monthIndex, day: 1),
+      c,
+    );
+    final monthLast = monthFirst + daysInMonth - 1;
     for (final e in events) {
-      final d = e.startDate;
-      if (d.year == year && d.monthIndex == monthIndex) {
-        byDay.putIfAbsent(d.day, () => []).add(e);
+      final start = engine.daysSinceEpoch(e.startDate.toEngine(), c);
+      final end = e.endDate == null
+          ? start
+          : engine.daysSinceEpoch(e.endDate!.toEngine(), c);
+      // Intersect [start, end] with [monthFirst, monthLast].
+      final from = start < monthFirst ? monthFirst : start;
+      final to = end > monthLast ? monthLast : end;
+      if (from > to) continue; // doesn't touch this month
+      for (var d = from; d <= to; d++) {
+        final dayInMonth = d - monthFirst + 1;
+        byDay.putIfAbsent(dayInMonth, () => []).add(e);
       }
     }
     final cells = firstWeekday + daysInMonth;

--- a/apps/dnd_calendar/lib/moon_strip.dart
+++ b/apps/dnd_calendar/lib/moon_strip.dart
@@ -1,0 +1,43 @@
+import 'package:calendar_engine/calendar_engine.dart' as engine;
+import 'package:flutter/material.dart';
+
+import 'models/world.dart';
+
+/// Compact one-line indicator like "🌒 Moon 5/28 · 🌕 Selûne 14/28".
+class MoonStrip extends StatelessWidget {
+  const MoonStrip({
+    super.key,
+    required this.calendar,
+    required this.date,
+    this.style,
+  });
+
+  final CalendarConfigData calendar;
+  final WorldDateData date;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = calendar.toEngine();
+    final phases = engine.moonPhasesAt(date.toEngine(), c);
+    if (phases.isEmpty) {
+      return Text(
+        'No moons configured.',
+        style: style ?? Theme.of(context).textTheme.bodySmall,
+      );
+    }
+    final defaultStyle = style ?? Theme.of(context).textTheme.bodyMedium;
+    return Wrap(
+      spacing: 12,
+      runSpacing: 4,
+      children: [
+        for (final p in phases)
+          Text(
+            '${p.phase.symbol} ${p.moon.name} '
+            '${p.dayInCycle + 1}/${p.moon.periodDays}',
+            style: defaultStyle,
+          ),
+      ],
+    );
+  }
+}

--- a/apps/dnd_calendar/lib/world_detail_screen.dart
+++ b/apps/dnd_calendar/lib/world_detail_screen.dart
@@ -8,6 +8,8 @@ import 'calendar_config_edit_screen.dart';
 import 'characters_section.dart';
 import 'events_section.dart';
 import 'models/world.dart';
+import 'moon_strip.dart';
+import 'world_date_picker.dart';
 import 'world_providers.dart';
 
 class WorldDetailScreen extends ConsumerWidget {
@@ -61,14 +63,14 @@ class WorldDetailScreen extends ConsumerWidget {
   }
 }
 
-class _OverviewTab extends StatelessWidget {
+class _OverviewTab extends ConsumerWidget {
   const _OverviewTab({required this.world, required this.isOwner});
 
   final World world;
   final bool isOwner;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cal = world.calendar.toEngine();
     final today = world.calendar.currentDate.toEngine();
     return ListView(
@@ -79,6 +81,44 @@ class _OverviewTab extends StatelessWidget {
         else
           Text('Role: player', style: Theme.of(context).textTheme.bodySmall),
         const Divider(height: 32),
+        // Today + moons + advance controls
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text('Today', style: Theme.of(context).textTheme.bodySmall),
+                const SizedBox(height: 4),
+                Text(
+                  engine.formatDate(today, cal),
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                MoonStrip(calendar: world.calendar, date: world.calendar.currentDate),
+                if (isOwner) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    children: [
+                      OutlinedButton.icon(
+                        icon: const Icon(Icons.add),
+                        label: const Text('+1 day'),
+                        onPressed: () => _advanceOneDay(context, ref),
+                      ),
+                      OutlinedButton.icon(
+                        icon: const Icon(Icons.calendar_today),
+                        label: const Text('Set date…'),
+                        onPressed: () => _pickDate(context, ref),
+                      ),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
         Row(
           children: [
             Expanded(
@@ -103,7 +143,6 @@ class _OverviewTab extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
-        _kv(context, 'Today', engine.formatDate(today, cal)),
         _kv(context, 'Week length', '${cal.daysPerWeek} days'),
         _kv(
           context,
@@ -112,7 +151,11 @@ class _OverviewTab extends StatelessWidget {
               '(${cal.months.length} months)',
         ),
         _kv(context, 'Epoch', cal.epochName),
-        _kv(context, 'Moons', cal.moons.map((m) => m.name).join(', ')),
+        _kv(
+          context,
+          'Moons',
+          cal.moons.isEmpty ? 'none' : cal.moons.map((m) => m.name).join(', '),
+        ),
         if (cal.leapRule != null)
           _kv(
             context,
@@ -121,14 +164,62 @@ class _OverviewTab extends StatelessWidget {
           )
         else
           _kv(context, 'Leap rule', 'none'),
-        const SizedBox(height: 32),
-        const Divider(),
-        const Text(
-          'Characters and quest registration land in later slices.',
-          style: TextStyle(fontSize: 12),
-        ),
       ],
     );
+  }
+
+  Future<void> _advanceOneDay(BuildContext context, WidgetRef ref) async {
+    final cal = world.calendar.toEngine();
+    final next = engine.addDays(world.calendar.currentDate.toEngine(), 1, cal);
+    await _writeDate(context, ref, WorldDateData.fromEngine(next));
+  }
+
+  Future<void> _pickDate(BuildContext context, WidgetRef ref) async {
+    var picked = world.calendar.currentDate;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Set current date'),
+        content: SizedBox(
+          width: 360,
+          child: WorldDatePicker(
+            calendar: world.calendar,
+            initial: picked,
+            onChanged: (d) => picked = d,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Set'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !context.mounted) return;
+    await _writeDate(context, ref, picked);
+  }
+
+  Future<void> _writeDate(
+    BuildContext context,
+    WidgetRef ref,
+    WorldDateData newDate,
+  ) async {
+    try {
+      await ref
+          .read(worldRepositoryProvider)
+          .setCurrentDate(world.id, newDate);
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed: $e')),
+        );
+      }
+    }
   }
 
   Widget _kv(BuildContext context, String k, String v) => Padding(

--- a/apps/dnd_calendar/lib/world_repository.dart
+++ b/apps/dnd_calendar/lib/world_repository.dart
@@ -131,6 +131,17 @@ class WorldRepository {
     });
   }
 
+  /// Replace just `calendar.currentDate` — used by the DM "advance date"
+  /// quick controls on the world overview.
+  Future<void> setCurrentDate(
+    String worldId,
+    WorldDateData currentDate,
+  ) async {
+    await _worlds.doc(worldId).update({
+      'calendar.currentDate': currentDate.toJson(),
+    });
+  }
+
   static const _joinCodeAlphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
   static final _rng = Random.secure();
 


### PR DESCRIPTION
## Summary

Final MVP slice. Wires up the world's "today" so the upcoming/past distinction in S3 actually works, surfaces moon phases everywhere they're useful, and lights up the multi-day event UI that's been deferred since S3.

## What it adds

- **Date advancement** — DM-only "+1 day" and "Set date…" buttons on the new Today card (Overview tab). Writes a single `calendar.currentDate` field via `WorldRepository.setCurrentDate`. No auto-advance.
- **MoonStrip widget** — compact one-line "🌒 Moon 5/28 · 🌕 Selûne 14/28" indicators reused on Overview and Event Detail.
- **Multi-day events**:
  - EventEditScreen "Multi-day event" toggle → optional end-date picker
  - List view shows "start → end" when ranges differ
  - Month view paints every day in `[start, end]` that touches the viewed month, not just the start cell
- **Polish**: friendlier "no moons configured" line; calendar summary moves into a Today card.

## Test plan

- [x] `dart analyze` clean
- [ ] Manual: DM advances date by +1 → upcoming events near that date flip to past, moon phase indicator advances
- [ ] DM creates a 5-day event → both list and month view render the range correctly
- [ ] Overlap check on registration still respects the wider range (S6 already used `eventEndDate`)
- [ ] Player view: no advance controls visible

Closes #9