### PR TITLE
fix(mvp): make S1-S7 actually work end-to-end on emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ package-lock.json
 # Firebase CLI scratch — flutterfire writes per-app firebase.json with
 # project + app IDs; root-level firebase.json is committed for rules deploy.
 apps/*/firebase.json
+
+# Local debug artifacts produced by `flutter run | tee`
+.flutter_run.log
+.flutter_run_input

--- a/apps/dnd_calendar/build.yaml
+++ b/apps/dnd_calendar/build.yaml
@@ -1,0 +1,11 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          # Recurse into nested types when (de)serializing — required for our
+          # freezed-of-freezed shape (World.calendar, CalendarConfigData.months,
+          # CalendarConfigData.moons, CalendarConfigData.currentDate, etc.).
+          # Without this, the generated toJson dumps raw `_$XxxImpl` instances
+          # which Firestore rejects with "Invalid argument".
+          explicit_to_json: true

--- a/apps/dnd_calendar/lib/calendar_config_edit_screen.dart
+++ b/apps/dnd_calendar/lib/calendar_config_edit_screen.dart
@@ -202,7 +202,7 @@ class _CalendarConfigEditScreenState
           else
             TextButton(
               onPressed: _save,
-              child: const Text('Save', style: TextStyle(color: Colors.white)),
+              child: const Text('Save'),
             ),
         ],
       ),

--- a/apps/dnd_calendar/lib/characters_section.dart
+++ b/apps/dnd_calendar/lib/characters_section.dart
@@ -278,7 +278,7 @@ class _CharacterEditScreenState extends ConsumerState<CharacterEditScreen> {
           else
             TextButton(
               onPressed: _save,
-              child: const Text('Save', style: TextStyle(color: Colors.white)),
+              child: const Text('Save'),
             ),
         ],
       ),

--- a/apps/dnd_calendar/lib/event_edit_screen.dart
+++ b/apps/dnd_calendar/lib/event_edit_screen.dart
@@ -138,7 +138,7 @@ class _EventEditScreenState extends ConsumerState<EventEditScreen> {
           else
             TextButton(
               onPressed: _save,
-              child: const Text('Save', style: TextStyle(color: Colors.white)),
+              child: const Text('Save'),
             ),
         ],
       ),

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   }
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,39 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "worlds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ownerUid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "startDate.year", "order": "ASCENDING" },
+        { "fieldPath": "startDate.monthIndex", "order": "ASCENDING" },
+        { "fieldPath": "startDate.day", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": [
+    {
+      "collectionGroup": "members",
+      "fieldPath": "uid",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "registrations",
+      "fieldPath": "characterId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,7 +33,13 @@ service cloud.firestore {
     }
 
     match /worlds/{worldId} {
-      allow read: if canSeeWorld(worldId);
+      // Read uses the in-document `ownerUid` field directly so that
+      //   .where('ownerUid', isEqualTo: auth.uid)
+      // queries pass Firestore's static query-rule analysis. The
+      // alternative isMember(worldId) branch handles joined-as-player.
+      allow read: if signedIn()
+        && (resource.data.ownerUid == request.auth.uid
+            || isMember(worldId));
       allow create: if signedIn()
         && request.resource.data.ownerUid == request.auth.uid;
       allow update: if isOwner(worldId)
@@ -86,6 +92,28 @@ service cloud.firestore {
           && request.resource.data.uid == request.auth.uid;
         allow delete: if signedIn() && resource.data.uid == request.auth.uid;
       }
+    }
+
+    // Collection-group reads. The Flutter client uses two collectionGroup
+    // queries that cross world boundaries:
+    //   - watchJoinedWorldIds → collectionGroup('members').where(uid==me)
+    //   - register() overlap check → collectionGroup('registrations')
+    //                                .where(characterId==myCharacterId)
+    // Firestore's rules engine evaluates collectionGroup queries against
+    // top-level matches, so we add permissive read rules here. Writes are
+    // still funnelled through the per-world matches above.
+    match /{path=**}/members/{memberUid} {
+      // Match the field the collectionGroup query filters on
+      // (.where('uid', isEqualTo: auth.uid)) so Firestore's static
+      // query-rule analysis accepts it.
+      allow read: if signedIn() && resource.data.uid == request.auth.uid;
+    }
+    match /{path=**}/registrations/{regUid} {
+      // Overlap check needs to read registrations across worlds for one
+      // characterId. Sign-in is the only gate — registration data is
+      // already denormalized (character name, owner display name) and
+      // not sensitive enough to warrant a tighter rule.
+      allow read: if signedIn();
     }
 
     // Public-ish join-code lookup. Any signed-in user may read so the


### PR DESCRIPTION
## Summary

Sweep PR after running `flutter run` for the first time post-S0. Hit five hard-blocking bugs across S1–S6 that no PR caught because none of S1–S7 was ever exercised on a real device.

## Bugs

1. **collectionGroup queries denied** — `watchOwnedWorlds` and `watchJoinedWorldIds` rejected by Firestore static query-rule analysis. Worlds rule rewritten to use \`resource.data.ownerUid\` directly; new top-level \`match /{path=**}/members\` matches on field, not on dynamic \`get()\`.
2. **Missing composite + collectionGroup indexes** — failed-precondition on first run. New \`firestore.indexes.json\` ships:
   - \`worlds(ownerUid,-createdAt)\`
   - \`events(startDate.year,monthIndex,day)\`
   - \`COLLECTION_GROUP_ASC\` field overrides for \`members.uid\` and \`registrations.characterId\`
3. **`Invalid argument: _\$CalendarConfigDataImpl`** — generated `World.toJson()` was emitting raw freezed instances because `explicit_to_json` was off. Added `apps/dnd_calendar/build.yaml`. This blocked every Firestore write that touched a nested freezed model.
4. **Save buttons invisible** in event/character/calendar edit screens — `TextStyle(color: Colors.white)` on white M3 AppBar. Removed.
5. **Overlap collectionGroup query path** — same root cause as #1, fixed by the same top-level match.

## Verified end-to-end on emulator-5554

- ✅ S1: sign-in → world list → create world → appears under "You DM"
- ✅ S2: open world → edit calendar config screen renders + preview works
- ✅ S3: create event (single + multi-day) → list view shows date range, month view paints all intersecting cells
- ✅ S4: join code visible + copyable
- ✅ S5: create character → "Yours" section, edit/delete icons
- ✅ S6: sign up → roster updates, button flips to "Unregister (Drizzt)"; second event on overlapping day refuses registration
- ✅ S7: +1 day advances date + recomputes weekday + moon phase; multi-day event renders across three day cells

## Test plan

- [x] \`dart analyze\` — no issues
- [x] \`dart test\` (calendar_engine) — 30/30 pass
- [x] \`dart run build_runner build --delete-conflicting-outputs\` clean
- [x] e2e walk-through on emulator (described above)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)